### PR TITLE
[FEAT] 로깅 AOP 구현

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/aop/ExecutionLoggingAop.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/aop/ExecutionLoggingAop.java
@@ -1,0 +1,78 @@
+package com.nonsoolmate.nonsoolmateServer.global.aop;
+
+import com.nonsoolmate.nonsoolmateServer.global.security.CustomAuthUser;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Objects;
+import lombok.extern.log4j.Log4j2;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Component
+@Log4j2
+public class ExecutionLoggingAop {
+
+    // 모든 패키지 내의 controller package에 존재하는 클래스
+    @Around("execution(* com.nonsoolmate.nonsoolmateServer.domain..controller..*(..))")
+    public Object logExecutionTrace(ProceedingJoinPoint pjp) throws Throwable {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        RequestMethod httpMethod = RequestMethod.valueOf(request.getMethod());
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = 0L;
+        if (!authentication.getPrincipal().equals("anonymousUser")) {
+            CustomAuthUser customAuthUser = (CustomAuthUser) authentication.getPrincipal();
+            userId = customAuthUser.getMember().getMemberId();
+        }
+
+        String className = pjp.getSignature().getDeclaringType().getSimpleName();
+        String methodName = pjp.getSignature().getName();
+        String task = className + "." + methodName;
+
+        log.info("[Call Method] " + httpMethod.toString() + ": " + task + " | Request userId=" + userId.toString());
+
+        Object[] paramArgs = pjp.getArgs();
+        String loggingMessage = "";
+        int cnt = 1;
+        for (Object object : paramArgs) {
+            if (Objects.nonNull(object)) {
+                String paramName = "[param" + cnt +"] " + object.getClass().getSimpleName();
+                String paramValue = " [value" + cnt +"] " + object;
+                loggingMessage += paramName + paramValue + "\n";
+                cnt++;
+            }
+        }
+        log.info("{}", loggingMessage);
+        // 해당 클래스 처리 전의 시간
+        StopWatch sw = new StopWatch();
+        sw.start();
+
+        Object result = null;
+
+        // 해당 클래스의 메소드 실행
+        try{
+            result = pjp.proceed();
+        }
+        catch (Exception e){
+            log.warn("[ERROR] " + task + " 메서드 예외 발생 : " + e.getMessage());
+            throw e;
+        }
+
+        // 해당 클래스 처리 후의 시간
+        sw.stop();
+        long executionTime = sw.getTotalTimeMillis();
+
+        log.info("[ExecutionTime] " + task + " --> " + executionTime + " (ms)");
+
+        return result;
+    }
+
+}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
feat/#3 -> dev
closed #3

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 앞으로 실제 서비스 및 에러 디버깅을 위해 필요한 로깅 정보가 남도록 설정했습니다.
- 도커 컨테이너에서 EC2 호스트와 볼륨을 마운트해서 로깅 내용이 영구적으로 쌓이게 할 수 있는데 그 부분까진 구현하진 않았습니다!

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
* 로깅 내용은 아래와 같습니다.
    * 요청된 컨트롤러 클래스 이름
    * 요청된 유저 id
    * 요청값
    * 전체 실행시간
![스크린샷 2024-07-02 오후 3 22 34](https://github.com/nonsoolmate-official/nonsoolmate-server/assets/100754581/f54b0aaf-7833-4e68-b121-f2f9f0343f7f)

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 관련해서 수정 필요한 부분 있다면 편하게 말씀주세요 !!