### PR TITLE
[REFACTOR] 목표대학 설정 API 리팩토링

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/SelectUniversityController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/controller/SelectUniversityController.java
@@ -52,7 +52,11 @@ public class SelectUniversityController implements SelectUniversityApi {
             @AuthUser Member member,
             @RequestBody @Valid final List<SelectUniversityRequestDTO> request) {
 
+        List<Long> selectedUniversityIds = request.stream()
+                .map(SelectUniversityRequestDTO::universityId)
+                .toList();
+
         return ResponseEntity.ok().body(SuccessResponse.of(PATCH_SELECT_UNIVERSITIES_SUCCESS,
-                selectUniversityService.patchSelectUniversities(member, request)));
+                selectUniversityService.patchSelectUniversities(member, selectedUniversityIds)));
     }
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/repository/SelectUniversityRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/repository/SelectUniversityRepository.java
@@ -8,18 +8,12 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface SelectUniversityRepository extends JpaRepository<SelectUniversity, Long> {
-
-    List<SelectUniversity> findAllByMember(Member member);
+    void deleteAllByMember(Member member);
 
     @Query("select su from SelectUniversity su where su.member =:member order by su.university.universityName asc, su.university.universityCollege asc")
     List<SelectUniversity> findAllByMemberOrderByUniversityNameASCUniversityCollegeAsc(Member member);
 
     Optional<SelectUniversity> findByMemberAndUniversity(Member member, University university);
-
-    @Transactional
-    void deleteByMemberAndUniversity(Member member, University university);
-
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/repository/SelectUniversityRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/repository/SelectUniversityRepository.java
@@ -7,10 +7,16 @@ import com.nonsoolmate.nonsoolmateServer.domain.university.entity.University;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface SelectUniversityRepository extends JpaRepository<SelectUniversity, Long> {
-    void deleteAllByMember(Member member);
+
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("DELETE FROM SelectUniversity s WHERE s.member.memberId = :memberId")
+    void deleteAllByMemberId(Long memberId);
 
     @Query("select su from SelectUniversity su where su.member =:member order by su.university.universityName asc, su.university.universityCollege asc")
     List<SelectUniversity> findAllByMemberOrderByUniversityNameASCUniversityCollegeAsc(Member member);

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/service/SelectUniversityService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/service/SelectUniversityService.java
@@ -98,7 +98,7 @@ public class SelectUniversityService {
             Member member,
             List<Long> selectedUniversityIds) {
 
-        selectUniversityRepository.deleteAllByMember(member);
+        selectUniversityRepository.deleteAllByMemberId(member.getMemberId());
 
         List<University> universities = universityRepository.findAllByUniversityIdIn(selectedUniversityIds);
         List<SelectUniversity> selectUniversities = universities.stream()

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/repository/UniversityRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/repository/UniversityRepository.java
@@ -1,22 +1,14 @@
 package com.nonsoolmate.nonsoolmateServer.domain.university.repository;
 
-import static com.nonsoolmate.nonsoolmateServer.domain.selectUniversity.exception.SelectUniversityExceptionType.INVALID_SELECTED_UNIVERSITY;
-
-import com.nonsoolmate.nonsoolmateServer.domain.selectUniversity.exception.SelectUniversityException;
 import com.nonsoolmate.nonsoolmateServer.domain.university.entity.University;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UniversityRepository extends JpaRepository<University, Long> {
     List<University> findAll();
 
-    Optional<University> findByUniversityId(Long universityId);
-
     List<University> findAllByOrderByUniversityNameAscUniversityCollegeAsc();
 
-    default University findByUniversityIdOrElseThrowException(Long universityId){
-        return findByUniversityId(universityId).orElseThrow(
-                ()-> new SelectUniversityException(INVALID_SELECTED_UNIVERSITY));
-    }
+    List<University> findAllByUniversityIdIn(List<Long> universityIds);
+
 }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 리팩토링
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
feat/#6 -> dev
closed #6

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 허허,,, 테스트 코드를 작성하려다가 코드를 이것저것 살펴보면서 제가 1월에 작성한 코드를 다시 봤는데 말이 안되더라고요,,,
- 가독성이 최악이고, db쿼리도 말도 안되게 나가는 것 같아서 이 부분 간단히 개선해봤습니다!

### 대학 조회 쿼리
- 기존에 대학 조회 쿼리도 N번 나가는 구조여서 이 부분 1번 쿼리로 개선했습니다!

### delete 쿼리 및 insert 쿼리
- delete 쿼리도 bulk성으로 1번만 발생하지만, insert 쿼리는 요청한 수 만큼 나가는 구조인데요!
- 사실 저희 insert 쿼리가 끽해야 50번 미만일것 같아서 크게 문제 없다고 판단이 들어 이렇게 구현했습니다!
- 간단한 방법으로 jpa의 batch insert가 있을 것 같은데요! 적용하기엔 저희 엔티티 id 생성전략이 `IDENTITY` 로 되어 있어서 간단히 적용하긴 어려울 것 같아서 이렇게 PR 날려봅니다..!
    - 참고자료 : https://cheese10yun.github.io/jpa-batch-insert/
- insert(`saveAll`)와 통일성있게 delete도 `deleteAll` 이 더 좋다고 생각 드시면 편하게 의견 말씀주세요!!

## 📝 테스트 결과
<!-- local에서 postman으로
 요청한 결과를 첨부합니다 -->

<img width="866" alt="스크린샷 2024-07-03 오후 5 53 18" src="https://github.com/nonsoolmate-official/nonsoolmate-server/assets/100754581/15105365-e7c6-46c7-86ce-76174a57374c">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
