### PR TITLE
[FEAT] 시험지 조회(PDF) 구현

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityApi.java
@@ -29,7 +29,7 @@ public interface UniversityApi {
             }
     )
     @Operation(summary = "시험 보기: 시험 이름 & 제한 시간", description = "시험 응시 화면의 이름 및 제한 시간을 조회합니다.")
-    ResponseEntity<SuccessResponse<UniversityExamInfoResponseDTO>> getUniversityExam(
+    ResponseEntity<SuccessResponse<UniversityExamInfoResponseDTO>> getUniversityExamInfo(
             @Parameter(description = "해당 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long universityExamId);
 
     @ApiResponses(

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityApi.java
@@ -1,5 +1,6 @@
 package com.nonsoolmate.nonsoolmateServer.domain.university.controller;
 
+import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamFileResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamImageAndAnswerResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamImageResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamInfoResponseDTO;
@@ -30,6 +31,16 @@ public interface UniversityApi {
     @Operation(summary = "시험 보기: 시험 이름 & 제한 시간", description = "시험 응시 화면의 이름 및 제한 시간을 조회합니다.")
     ResponseEntity<SuccessResponse<UniversityExamInfoResponseDTO>> getUniversityExam(
             @Parameter(description = "해당 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long universityExamId);
+
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "200", description = "대학 시험지 조회에 성공했습니다"),
+                    @ApiResponse(responseCode = "400", description = "존재하지 않는 대학 시험입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    @Operation(summary = "시험 보기: 문제지 [PDF]", description = "시험 응시 화면의 문제지를 조회합니다.")
+    ResponseEntity<SuccessResponse<UniversityExamFileResponseDTO>> getUniversityExamFile(
+            @Parameter(description = "해당 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long id);
 
     @ApiResponses(
             value = {

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityExamController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityExamController.java
@@ -35,7 +35,7 @@ public class UniversityExamController implements UniversityApi{
     }
 
     @Override
-    @GetMapping("{id}")
+    @GetMapping("/{id}")
     public ResponseEntity<SuccessResponse<UniversityExamFileResponseDTO>> getUniversityExamFile(
             @PathVariable("id") final Long id) {
         return ResponseEntity.ok().body(SuccessResponse.of(UniversityExamSuccessType.GET_UNIVERSITY_EXAM_FILE_SUCCESS,

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityExamController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityExamController.java
@@ -28,10 +28,10 @@ public class UniversityExamController implements UniversityApi{
 
     @Override
     @GetMapping("/{id}/info")
-    public ResponseEntity<SuccessResponse<UniversityExamInfoResponseDTO>> getUniversityExam(
+    public ResponseEntity<SuccessResponse<UniversityExamInfoResponseDTO>> getUniversityExamInfo(
             @PathVariable("id") final Long universityExamId) {
         return ResponseEntity.ok().body(SuccessResponse.of(UniversityExamSuccessType.GET_UNIVERSITY_EXAM_SUCCESS,
-                universityExamService.getUniversityExam(universityExamId)));
+                universityExamService.getUniversityExamInfo(universityExamId)));
     }
 
     @Override

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityExamController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityExamController.java
@@ -2,6 +2,7 @@ package com.nonsoolmate.nonsoolmateServer.domain.university.controller;
 
 import static com.nonsoolmate.nonsoolmateServer.domain.university.exception.UniversityExamSuccessType.GET_UNIVERSITY_EXAM_IMAGE_AND_ANSWER_SUCCESS;
 
+import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamFileResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamImageAndAnswerResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamImageResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamInfoResponseDTO;
@@ -31,6 +32,14 @@ public class UniversityExamController implements UniversityApi{
             @PathVariable("id") final Long universityExamId) {
         return ResponseEntity.ok().body(SuccessResponse.of(UniversityExamSuccessType.GET_UNIVERSITY_EXAM_SUCCESS,
                 universityExamService.getUniversityExam(universityExamId)));
+    }
+
+    @Override
+    @GetMapping("{id}")
+    public ResponseEntity<SuccessResponse<UniversityExamFileResponseDTO>> getUniversityExamFile(
+            @PathVariable("id") final Long id) {
+        return ResponseEntity.ok().body(SuccessResponse.of(UniversityExamSuccessType.GET_UNIVERSITY_EXAM_FILE_SUCCESS,
+                universityExamService.getUniversityExamFile(id)));
     }
 
     @Override

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityExamController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityExamController.java
@@ -45,7 +45,7 @@ public class UniversityExamController implements UniversityApi{
     @Override
     @GetMapping("{id}/image")
     public ResponseEntity<SuccessResponse<Page<UniversityExamImageResponseDTO>>> getUniversityExamImages(
-            @PathVariable("id") final Long id, @RequestParam(defaultValue = "0") final int page, final Pageable pageable) {
+            @PathVariable("id") final Long id, @RequestParam(value="page", defaultValue = "0") final int page, final Pageable pageable) {
         PageRequest pageRequest = PageRequest.of(page, 1);
         Page<UniversityExamImageResponseDTO> images = universityExamService.getUniversityExamImages(id, pageRequest);
         return ResponseEntity.ok()

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamFileResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamFileResponseDTO.java
@@ -1,0 +1,11 @@
+package com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record UniversityExamFileResponseDTO(
+        @Schema(description = "시험 문제 PDF URL") String universityExamFileNameUrl
+) {
+    public static UniversityExamFileResponseDTO of(final String universityExamFileNameUrl) {
+        return new UniversityExamFileResponseDTO(universityExamFileNameUrl);
+    }
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/entity/UniversityExam.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/entity/UniversityExam.java
@@ -30,6 +30,9 @@ public class UniversityExam {
     private String universityExamName;
 
     @NotNull
+    private String universityExamFileName;
+
+    @NotNull
     private String universityExamAnswerFileName;
 
     @NotNull

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/exception/UniversityExamSuccessType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/exception/UniversityExamSuccessType.java
@@ -11,7 +11,9 @@ public enum UniversityExamSuccessType implements SuccessType {
      * 200 OK
      */
     GET_UNIVERSITY_EXAM_SUCCESS(HttpStatus.OK, "대학 시험 정보 조회에 성공했습니다"),
+    // TODO: 이미지 조회에서 PDF 조회로 변경되면 지워야 함
     GET_UNIVERSITY_EXAM_IMAGE_SUCCESS(HttpStatus.OK, "대학 시험 이미지 조회에 성공했습니다"),
+    GET_UNIVERSITY_EXAM_FILE_SUCCESS(HttpStatus.OK, "대학 시험 파일 조회에 성공했습니다"),
     GET_UNIVERSITY_EXAM_IMAGE_AND_ANSWER_SUCCESS(HttpStatus.OK, "대학 시험 이미지 및 해제 PDF 조회에 성공했습니다");
 
 

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/service/UniversityExamService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/service/UniversityExamService.java
@@ -1,8 +1,6 @@
 package com.nonsoolmate.nonsoolmateServer.domain.university.service;
 
-import static com.nonsoolmate.nonsoolmateServer.external.aws.FolderName.EXAM_ANSWER_FOLDER_NAME;
-import static com.nonsoolmate.nonsoolmateServer.external.aws.FolderName.EXAM_IMAGE_FOLDER_NAME;
-
+import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamFileResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamImageAndAnswerResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamImageResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamInfoResponseDTO;
@@ -21,6 +19,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.nonsoolmate.nonsoolmateServer.domain.university.repository.UniversityExamRepository;
 
+import static com.nonsoolmate.nonsoolmateServer.external.aws.FolderName.*;
+
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -38,6 +38,14 @@ public class UniversityExamService {
         return UniversityExamInfoResponseDTO.of(universityExam.getUniversityExamId(),
                 universityExamName,
                 universityExam.getUniversityExamTimeLimit());
+    }
+
+    public UniversityExamFileResponseDTO getUniversityExamFile(final Long id) {
+        UniversityExam universityExam = universityExamRepository.findByUniversityExamId(id)
+                .orElseThrow(() -> new UniversityExamException(
+                        UniversityExamExceptionType.INVALID_UNIVERSITY_EXAM));
+        return UniversityExamFileResponseDTO.of(cloudFrontService.createPreSignedGetUrl(EXAM_FILE_FOLDER_NAME,
+                universityExam.getUniversityExamFileName()));
     }
 
     public Page<UniversityExamImageResponseDTO> getUniversityExamImages(final Long id, final Pageable pageable) {

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/service/UniversityExamService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/service/UniversityExamService.java
@@ -30,7 +30,7 @@ public class UniversityExamService {
     private final CloudFrontService cloudFrontService;
 
 
-    public UniversityExamInfoResponseDTO getUniversityExam(final Long universityExamId) {
+    public UniversityExamInfoResponseDTO getUniversityExamInfo(final Long universityExamId) {
         UniversityExam universityExam = universityExamRepository.findByUniversityExamId(universityExamId)
                 .orElseThrow(() -> new UniversityExamException(
                         UniversityExamExceptionType.INVALID_UNIVERSITY_EXAM));

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/aws/FolderName.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/aws/FolderName.java
@@ -4,5 +4,7 @@ public abstract class FolderName {
     public static final String EXAM_ANSWER_FOLDER_NAME = "exam-answer/";
     public static final String EXAM_RESULT_FOLDER_NAME = "exam-result/";
     public static final String EXAM_SHEET_FOLDER_NAME = "exam-sheet/";
+    // TODO: exma-image -> 사용안해도 되는 기간에 삭제
     public static final String EXAM_IMAGE_FOLDER_NAME = "exam-image/";
+    public static final String EXAM_FILE_FOLDER_NAME = "exam-pdf/";
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/jwt/utils/PasswordUtil.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/jwt/utils/PasswordUtil.java
@@ -23,7 +23,7 @@ public class PasswordUtil {
 
             password.append(charSet[index]);
         }
-        System.out.println(password);
+//        System.out.println(password);
         return password.toString();
         //StringBuffer를 String으로 변환해서 return 하려면 toString()을 사용하면 된다.
     }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#5 -> dev
- closed #5 


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- UniversityExam 엔티티에 시험 문제 Pdf 경로를 저장할 필드를 추가했습니다(university_exam_file_name)
- db 스크립트(create, dummy) 노션에 업데이트 해두었습니다!
- Rds에는 alter문으로 컬럼 추가해두었습니다
- 현재 제 로컬에서는 시험지명이 영어일 때만 조회가 가능한 상황입니다(사진 첨부) 그러나 인코딩 문제라기에는 한글이름으로 되어있는 시험 문제 이미지는 조회가 잘 되는 상황입니다
- 민규님 로컬에서 한 번 실행해보고 문제 없으면 test 서버에까지 반영된 이후에 클라테스트 해보는게 좋을 것 같습니다! 관련해서는 좀 더 찾아보겠습니도  


## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="740" alt="image" src="https://github.com/nonsoolmate-official/nonsoolmate-server/assets/81363864/c301dc94-21d8-454c-b491-9dd938b41826">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- @mikekks 그리고 현재 password를 제가 주석처리해두었는데 저희 서비스에서 필요하지 않은 기능인 것 같아서 관련 클래스를 지우는건 어떨지 여쭤봅니다!!
