### PR TITLE
[FEAT] 해제: 문제PDF_해제PDF 조회 기능 구현

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityApi.java
@@ -1,9 +1,6 @@
 package com.nonsoolmate.nonsoolmateServer.domain.university.controller;
 
-import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamFileResponseDTO;
-import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamImageAndAnswerResponseDTO;
-import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamImageResponseDTO;
-import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamInfoResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.*;
 import com.nonsoolmate.nonsoolmateServer.global.response.ErrorResponse;
 import com.nonsoolmate.nonsoolmateServer.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -71,6 +68,6 @@ public interface UniversityApi {
             }
     )
     @Operation(summary= "해제: 문제PDF_해제PDF", description = "시험 문제 및 해제 PDF를 조회합니다.")
-    ResponseEntity<SuccessResponse<UniversityExamImageAndAnswerResponseDTO>> getUniversityExamAndAnswer(
+    ResponseEntity<SuccessResponse<UniversityExamAndAnswerResponseDTO>> getUniversityExamAndAnswer(
             @PathVariable("id") Long universityExamId);
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityApi.java
@@ -34,7 +34,7 @@ public interface UniversityApi {
 
     @ApiResponses(
             value = {
-                    @ApiResponse(responseCode = "200", description = "대학 시험지 조회에 성공했습니다"),
+                    @ApiResponse(responseCode = "200", description = "대학 시험 파일 조회에 성공했습니다"),
                     @ApiResponse(responseCode = "400", description = "존재하지 않는 대학 시험입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
@@ -62,5 +62,15 @@ public interface UniversityApi {
     )
     @Operation(summary= "해제: 문제이미지_해제PDF", description = "시험 문제 이미지 및 해제 PDF를 조회합니다.")
     ResponseEntity<SuccessResponse<UniversityExamImageAndAnswerResponseDTO>> getUniversityExamImageAndAnswer(
+            @PathVariable("id") Long universityExamId);
+
+    @ApiResponses(
+            value = {
+                    @ApiResponse(responseCode = "201", description = "대학 시험 문제 및 해제 PDF 조회에 성공했습니다"),
+                    @ApiResponse(responseCode = "400", description = "존재하지 않는 대학 시험입니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            }
+    )
+    @Operation(summary= "해제: 문제PDF_해제PDF", description = "시험 문제 및 해제 PDF를 조회합니다.")
+    ResponseEntity<SuccessResponse<UniversityExamImageAndAnswerResponseDTO>> getUniversityExamAndAnswer(
             @PathVariable("id") Long universityExamId);
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityExamController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityExamController.java
@@ -1,11 +1,9 @@
 package com.nonsoolmate.nonsoolmateServer.domain.university.controller;
 
+import static com.nonsoolmate.nonsoolmateServer.domain.university.exception.UniversityExamSuccessType.GET_UNIVERSITY_EXAM_AND_ANSWER_SUCCESS;
 import static com.nonsoolmate.nonsoolmateServer.domain.university.exception.UniversityExamSuccessType.GET_UNIVERSITY_EXAM_IMAGE_AND_ANSWER_SUCCESS;
 
-import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamFileResponseDTO;
-import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamImageAndAnswerResponseDTO;
-import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamImageResponseDTO;
-import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamInfoResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.*;
 import com.nonsoolmate.nonsoolmateServer.domain.university.exception.UniversityExamSuccessType;
 import com.nonsoolmate.nonsoolmateServer.domain.university.service.UniversityExamService;
 import com.nonsoolmate.nonsoolmateServer.global.response.SuccessResponse;
@@ -59,5 +57,14 @@ public class UniversityExamController implements UniversityApi{
     ) {
         return ResponseEntity.ok().body(SuccessResponse.of(GET_UNIVERSITY_EXAM_IMAGE_AND_ANSWER_SUCCESS,
                 universityExamService.getUniversityExamImageAndAnswer(universityExamId)));
+    }
+
+    @Override
+    @GetMapping("/v2/{id}/answer")
+    public ResponseEntity<SuccessResponse<UniversityExamAndAnswerResponseDTO>> getUniversityExamAndAnswer(
+            @PathVariable("id") Long universityExamId
+    ) {
+        return ResponseEntity.ok().body(SuccessResponse.of(GET_UNIVERSITY_EXAM_AND_ANSWER_SUCCESS,
+                universityExamService.getUniversityExamAndAnswer(universityExamId)));
     }
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityExamController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/UniversityExamController.java
@@ -59,6 +59,7 @@ public class UniversityExamController implements UniversityApi{
                 universityExamService.getUniversityExamImageAndAnswer(universityExamId)));
     }
 
+    // TODO: 이미지 조회에서 PDF 조회로 변경되면 mapping 경로 변경
     @Override
     @GetMapping("/v2/{id}/answer")
     public ResponseEntity<SuccessResponse<UniversityExamAndAnswerResponseDTO>> getUniversityExamAndAnswer(

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamAndAnswerResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamAndAnswerResponseDTO.java
@@ -7,12 +7,12 @@ import java.util.List;
 @Schema(name = "UniversityExamAndAnswerResponseDTO", description = "대학시험 문제PDF_해제PDF 조회 응답 DTO")
 public record UniversityExamAndAnswerResponseDTO(
         @Schema(description = "시험 이름(대학 + 시험 년도 + 시험 이름)", example = "2023 중앙대학교 경영경제 1") String universityExamName,
-        @Schema(description = "시험 문제 이미지 리스트") String universityExamFileUrl,
+        @Schema(description = "시험 문제 이미지 리스트") String universityExamUrl,
         @Schema(description = "이미지 해제 PDF URL") String universityExamAnswerUrl
 ) {
     public static UniversityExamAndAnswerResponseDTO of(final String universityExamName,
-                                                        final String universityExamFileUrl,
+                                                        final String universityExamUrl,
                                                         final String universityExamAnswerUrl) {
-        return new UniversityExamAndAnswerResponseDTO(universityExamName, universityExamFileUrl, universityExamAnswerUrl);
+        return new UniversityExamAndAnswerResponseDTO(universityExamName, universityExamUrl, universityExamAnswerUrl);
     }
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamAndAnswerResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamAndAnswerResponseDTO.java
@@ -7,7 +7,7 @@ import java.util.List;
 @Schema(name = "UniversityExamAndAnswerResponseDTO", description = "대학시험 문제PDF_해제PDF 조회 응답 DTO")
 public record UniversityExamAndAnswerResponseDTO(
         @Schema(description = "시험 이름(대학 + 시험 년도 + 시험 이름)", example = "2023 중앙대학교 경영경제 1") String universityExamName,
-        @Schema(description = "시험 문제 이미지 리스트") String universityExamUrl,
+        @Schema(description = "시험 문제 PDF URL") String universityExamUrl,
         @Schema(description = "이미지 해제 PDF URL") String universityExamAnswerUrl
 ) {
     public static UniversityExamAndAnswerResponseDTO of(final String universityExamName,

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamAndAnswerResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamAndAnswerResponseDTO.java
@@ -1,0 +1,18 @@
+package com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(name = "UniversityExamAndAnswerResponseDTO", description = "대학시험 문제PDF_해제PDF 조회 응답 DTO")
+public record UniversityExamAndAnswerResponseDTO(
+        @Schema(description = "시험 이름(대학 + 시험 년도 + 시험 이름)", example = "2023 중앙대학교 경영경제 1") String universityExamName,
+        @Schema(description = "시험 문제 이미지 리스트") String universityExamFileUrl,
+        @Schema(description = "이미지 해제 PDF URL") String universityExamAnswerUrl
+) {
+    public static UniversityExamAndAnswerResponseDTO of(final String universityExamName,
+                                                        final String universityExamFileUrl,
+                                                        final String universityExamAnswerUrl) {
+        return new UniversityExamAndAnswerResponseDTO(universityExamName, universityExamFileUrl, universityExamAnswerUrl);
+    }
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamFileResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamFileResponseDTO.java
@@ -2,8 +2,9 @@ package com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.respo
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(name = "UniversityExamFileResponseDTO", description = "대학시험 문제 PDF 조회 응답 DTO")
 public record UniversityExamFileResponseDTO(
-        @Schema(description = "시험 문제 PDF URL") String universityExamFileUrl
+        @Schema(description = "시험 문제 PDF URL") String universityExamUrl
 ) {
     public static UniversityExamFileResponseDTO of(final String universityExamFileUrl) {
         return new UniversityExamFileResponseDTO(universityExamFileUrl);

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamFileResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/dto/response/UniversityExamFileResponseDTO.java
@@ -3,9 +3,9 @@ package com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.respo
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record UniversityExamFileResponseDTO(
-        @Schema(description = "시험 문제 PDF URL") String universityExamFileNameUrl
+        @Schema(description = "시험 문제 PDF URL") String universityExamFileUrl
 ) {
-    public static UniversityExamFileResponseDTO of(final String universityExamFileNameUrl) {
-        return new UniversityExamFileResponseDTO(universityExamFileNameUrl);
+    public static UniversityExamFileResponseDTO of(final String universityExamFileUrl) {
+        return new UniversityExamFileResponseDTO(universityExamFileUrl);
     }
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/exception/UniversityExamSuccessType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/exception/UniversityExamSuccessType.java
@@ -14,7 +14,8 @@ public enum UniversityExamSuccessType implements SuccessType {
     // TODO: 이미지 조회에서 PDF 조회로 변경되면 지워야 함
     GET_UNIVERSITY_EXAM_IMAGE_SUCCESS(HttpStatus.OK, "대학 시험 이미지 조회에 성공했습니다"),
     GET_UNIVERSITY_EXAM_FILE_SUCCESS(HttpStatus.OK, "대학 시험 파일 조회에 성공했습니다"),
-    GET_UNIVERSITY_EXAM_IMAGE_AND_ANSWER_SUCCESS(HttpStatus.OK, "대학 시험 이미지 및 해제 PDF 조회에 성공했습니다");
+    GET_UNIVERSITY_EXAM_IMAGE_AND_ANSWER_SUCCESS(HttpStatus.OK, "대학 시험 이미지 및 해제 PDF 조회에 성공했습니다"),
+    GET_UNIVERSITY_EXAM_AND_ANSWER_SUCCESS(HttpStatus.OK, "대학 시험 문제 및 해제 PDF 조회에 성공했습니다");
 
 
     private final HttpStatus status;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/service/UniversityExamService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/service/UniversityExamService.java
@@ -1,9 +1,6 @@
 package com.nonsoolmate.nonsoolmateServer.domain.university.service;
 
-import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamFileResponseDTO;
-import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamImageAndAnswerResponseDTO;
-import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamImageResponseDTO;
-import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.UniversityExamInfoResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.*;
 import com.nonsoolmate.nonsoolmateServer.domain.university.entity.UniversityExam;
 import com.nonsoolmate.nonsoolmateServer.domain.university.entity.UniversityExamImage;
 import com.nonsoolmate.nonsoolmateServer.domain.university.exception.UniversityExamException;
@@ -82,6 +79,15 @@ public class UniversityExamService {
         return UniversityExamImageAndAnswerResponseDTO.of(
                 universityExam.getUniversityExamFullName()
                 , examImageUrls, examAnswerUrl);
+    }
+
+    public UniversityExamAndAnswerResponseDTO getUniversityExamAndAnswer(final long universityExamId){
+        UniversityExam universityExam = universityExamRepository.findByUniversityExamId(universityExamId)
+                .orElseThrow(() -> new UniversityExamException(
+                        UniversityExamExceptionType.INVALID_UNIVERSITY_EXAM));
+        String universityExamUrl = cloudFrontService.createPreSignedGetUrl(EXAM_FILE_FOLDER_NAME, universityExam.getUniversityExamFileName());
+        String universityAnswerUrl = cloudFrontService.createPreSignedGetUrl(EXAM_ANSWER_FOLDER_NAME, universityExam.getUniversityExamAnswerFileName());
+        return UniversityExamAndAnswerResponseDTO.of(universityExam.getUniversityExamFullName(), universityExamUrl, universityAnswerUrl);
     }
 
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#9 -> dev
- closed #9

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 문제 이미지와 해제 pdf를 반환하던 기능을 문제 pdf로 조회하도록 새롭게 기능을 만들었습니다
- 현재 기존 API가 클라분들 Q/A 하실 때 계속 사용중이시기도하고 아직 PDF로 수정작업을 안하고계셔서 앞에 /v2를 넣어 기존 경로와 다르게 설정해두었습니다
  - 나중에는 v2 뺀 경로대로 배포하면 될 것 같습니도
- pdf URL 문제 저도 복붙해서 해결했습니다 ㅎ.ㅎ 감사합니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="1392" alt="스크린샷 2024-07-05 오후 4 27 18" src="https://github.com/nonsoolmate-official/nonsoolmate-server/assets/81363864/d0f2415c-647b-4b23-aa16-f3f389c802a3">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 저는 이게 제 기능인줄 알았는데 명세서보니까 오빠가 구현했던 기능이더라고요! 그래서 responseDTO 필드명을 확인하게 되었는데 오빠랑 저랑 통일감이 없어서 일요일 회의 때 논의하면 좋을 것 같습니다!
