### PR TITLE
[FEAT] 내 프로필 조회 API 구현

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/MemberApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/MemberApi.java
@@ -3,6 +3,7 @@ package com.nonsoolmate.nonsoolmateServer.domain.member.controller;
 import org.springframework.http.ResponseEntity;
 
 import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.NameResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.ProfileResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.TicketResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
 import com.nonsoolmate.nonsoolmateServer.global.response.SuccessResponse;
@@ -32,4 +33,11 @@ public interface MemberApi {
 	@Operation(summary = "내 정보 확인: 첨삭권 개수", description = "내 첨삭권 갯수를 조회합니다.")
 	ResponseEntity<SuccessResponse<TicketResponseDTO>> getTicket(@AuthUser Member member);
 
+	@ApiResponses(
+		value = {
+			@ApiResponse(responseCode = "200", description = "프로필 조회에 성공하였습니다.")
+		}
+	)
+	@Operation(summary = "내 프로필 조회", description = "내 프로필을 조회합니다.")
+	ResponseEntity<SuccessResponse<ProfileResponseDTO>> getProfile(@AuthUser Member member);
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/MyController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/MyController.java
@@ -1,11 +1,14 @@
 package com.nonsoolmate.nonsoolmateServer.domain.member.controller;
 
+import static com.nonsoolmate.nonsoolmateServer.domain.member.exception.MemberSuccessType.*;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.NameResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.ProfileResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.TicketResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
 import com.nonsoolmate.nonsoolmateServer.domain.member.exception.MemberSuccessType;
@@ -35,5 +38,13 @@ public class MyController implements MemberApi {
 		return ResponseEntity.ok()
 			.body(SuccessResponse.of(MemberSuccessType.GET_MEMBER_TICKET_SUCCESS,
 				memberService.getTicket(member)));
+	}
+
+	@Override
+	@GetMapping("/profile")
+	public ResponseEntity<SuccessResponse<ProfileResponseDTO>> getProfile(@AuthUser final Member member) {
+		ProfileResponseDTO responseDTO = memberService.getProfile(member);
+
+		return ResponseEntity.ok().body(SuccessResponse.of(GET_MEMBER_PROFILE_SUCCESS, responseDTO));
 	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/dto/response/ProfileResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/controller/dto/response/ProfileResponseDTO.java
@@ -1,0 +1,24 @@
+package com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "ProfileResponseDTO", description = "프로필 조회 응답 DTO")
+public record ProfileResponseDTO(
+	@Schema(description = "멤버 이름", example = "홍길동")
+	String name,
+	@Schema(description = "성별", example = "M")
+	String gender,
+	@Schema(description = "태어난 연도", example = "2005")
+	String birthday,
+	@Schema(description = "이메일", example = "qwer@gmail.com")
+	String email,
+	@Schema(description = "전화번호", example = "010-1234-5678")
+	String phoneNumber
+) {
+	public static ProfileResponseDTO of(final String name, final String gender, final String birthday,
+		final String email, final String phoneNumber) {
+
+		return new ProfileResponseDTO(name, gender, birthday, email, phoneNumber);
+	}
+
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/exception/MemberSuccessType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/exception/MemberSuccessType.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MemberSuccessType implements SuccessType {
 	GET_MEMBER_NAME_SUCCESS(HttpStatus.OK, "이름 조회에 성공하였습니다."),
-	GET_MEMBER_TICKET_SUCCESS(HttpStatus.OK, "첨삭권 개수 조회에 성공하였습니다.");
+	GET_MEMBER_TICKET_SUCCESS(HttpStatus.OK, "첨삭권 개수 조회에 성공하였습니다."),
+	GET_MEMBER_PROFILE_SUCCESS(HttpStatus.OK, "프로필 조회에 성공하였습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepository.java
@@ -17,7 +17,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	Optional<Member> findByMemberId(Long memberId);
 
-	default Member findByMemberIdOrElseThrowException(Long memberId) {
+	default Member findByMemberIdOrElseThrow(Long memberId) {
 		return findByMemberId(memberId).orElseThrow(
 			() -> new AuthException(NOT_FOUND_MEMBER));
 	}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/service/MemberService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/service/MemberService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.NameResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.ProfileResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.TicketResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
 import com.nonsoolmate.nonsoolmateServer.domain.member.repository.MemberRepository;
@@ -22,5 +23,12 @@ public class MemberService {
 
 	public TicketResponseDTO getTicket(final Member member) {
 		return TicketResponseDTO.of(member.getName(), member.getTicketCount());
+	}
+
+	public ProfileResponseDTO getProfile(final Member member) {
+		Member foundMember = memberRepository.findByMemberIdOrElseThrow(member.getMemberId());
+
+		return ProfileResponseDTO.of(foundMember.getName(), foundMember.getGender(), foundMember.getBirthYear(),
+			foundMember.getEmail(), foundMember.getPhoneNumber());
 	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/security/service/MemberAuthService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/security/service/MemberAuthService.java
@@ -19,7 +19,7 @@ public class MemberAuthService implements UserDetailsService {
 
 	@Override
 	public UserDetails loadUserByUsername(String memberId) throws UsernameNotFoundException {
-		Member member = memberRepository.findByMemberIdOrElseThrowException(Long.parseLong(memberId));
+		Member member = memberRepository.findByMemberIdOrElseThrow(Long.parseLong(memberId));
 
 		String password = PasswordUtil.generateRandomPassword();
 


### PR DESCRIPTION
## 📝 PR 타입
- [X] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
feat/#23 -> dev
closed #23 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 사실 컨트롤러에서 받은 Member를 사용하여 굳이 service레이어 까지 내려갈 필요 없이 구현할 수 있는데요! 
- 그럼에도 불구하고, 이렇게 구현한 이유는 그러한 패턴이 안티패턴이라고 들어서 그랬습니다..!
- 사실 지금 서비스 레이어까지 내려가지 않더라도 크게 문제는 없습니다! 
- 문제가 생기는 시점은 Member 테이블에 `@oneToMany `나 `@ManyToOne `과 같이 연관관계가 붙기 시작할 때 부터인데요!
- 저희가 osiv가 false로 설정되어 있는 만큼 영속성 컨텍스트가 서비스 레이어부터 시작되는데요! 
- 하지만 컨트롤러에서 받은 `Member` 객체는 필터 단에서 조회한 것이잖아요??
- 그래서 Lazy loading 으로 연관관계가 있는 객체를 조회할 때, `LazyInitializationException` 이 발생합니다! 
- 추후에 이런 오류를 고려하여 이렇게 코드를 작성했습니다!

- 번외로 이러한 이슈 때문에 스프링 시큐리티에 Member 객체 전부를 넣는 것보다 memberId만 넣어서 service 레이어에서 멤버 객체를 조회하는게 더 나은 패턴이라고 하더라고요! 

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="846" alt="스크린샷 2024-07-10 오후 2 58 05" src="https://github.com/nonsoolmate-official/nonsoolmate-server/assets/100754581/5945f54b-a672-4ec9-a0a1-ce27b03e0b4c">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
