### PR TITLE
[FIX] 네이버 소셜 로그인 동시성 이슈 해결

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/exception/AuthExceptionType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/exception/AuthExceptionType.java
@@ -17,6 +17,7 @@ public enum AuthExceptionType implements ExceptionType {
 	INVALID_PLATFORM_TYPE(HttpStatus.BAD_REQUEST, "올바르지 않은 플랫폼 유형입니다."),
 	INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "서비스에서 발급되지 않은 액세스 토큰입니다."),
 	INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "서비스에서 발급되지 않거나 이미 사용된 리프레시 토큰입니다."),
+	INVALID_REQUEST_LOGIN(HttpStatus.BAD_REQUEST, "올바르지 않은 로그인 요청입니다"),
 
 	/**
 	 * 401 Unauthorized

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/service/AuthService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/service/AuthService.java
@@ -1,6 +1,10 @@
 package com.nonsoolmate.nonsoolmateServer.domain.auth.service;
 
+import org.springframework.dao.DataIntegrityViolationException;
+
 import com.nonsoolmate.nonsoolmateServer.domain.auth.controller.dto.request.MemberRequestDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.auth.exception.AuthException;
+import com.nonsoolmate.nonsoolmateServer.domain.auth.exception.AuthExceptionType;
 import com.nonsoolmate.nonsoolmateServer.domain.auth.service.vo.MemberSignUpVO;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.enums.PlatformType;
@@ -25,7 +29,7 @@ public abstract class AuthService {
 	public abstract MemberSignUpVO saveMemberOrLogin(final String platformType, final MemberRequestDTO request);
 
 	protected Member getMember(final PlatformType platformType, final String email) {
-		return memberRepository.findByPlatformTypeAndEmail(platformType, email)
+		return memberRepository.findByPlatformTypeAndPlatformId(platformType, email)
 			.orElse(null);
 	}
 
@@ -33,6 +37,10 @@ public abstract class AuthService {
 		final String name, final String birthday, final String gender, final String phoneNumber) {
 		Member newMember = createSocialMember(email, name, platformType, platformId, birthday, gender,
 			phoneNumber);
-		return memberRepository.saveAndFlush(newMember);
+		try {
+			return memberRepository.saveAndFlush(newMember);
+		} catch (DataIntegrityViolationException e) {
+			throw new AuthException(AuthExceptionType.INVALID_REQUEST_LOGIN);
+		}
 	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/service/AuthService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/service/AuthService.java
@@ -1,6 +1,5 @@
 package com.nonsoolmate.nonsoolmateServer.domain.auth.service;
 
-import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nonsoolmate.nonsoolmateServer.domain.auth.controller.dto.request.MemberRequestDTO;
@@ -12,15 +11,15 @@ import com.nonsoolmate.nonsoolmateServer.domain.member.repository.MemberReposito
 
 import lombok.RequiredArgsConstructor;
 
-@Service
 @RequiredArgsConstructor
 public abstract class AuthService {
 	private final MemberRepository memberRepository;
 
 	private static Member createSocialMember(final String email, final String name, final PlatformType platformType,
-		final String birthYear,
+		final String platformId, final String birthYear,
 		final String gender, final String phoneNumber) {
 		return Member.builder().email(email).name(name).platformType(platformType).role(Role.USER)
+			.platformId(platformId)
 			.birthYear(birthYear)
 			.gender(gender).phoneNumber(phoneNumber).build();
 	}
@@ -33,10 +32,9 @@ public abstract class AuthService {
 			.orElse(null);
 	}
 
-	protected Member saveUser(final MemberRequestDTO request, final String email, final String name,
-		final String birthday, final String gender,
-		final String phoneNumber) {
-		Member newMember = createSocialMember(email, name, PlatformType.of(request.platformType()), birthday, gender,
+	protected Member saveMember(final PlatformType platformType, final String platformId, final String email,
+		final String name, final String birthday, final String gender, final String phoneNumber) {
+		Member newMember = createSocialMember(email, name, platformType, platformId, birthday, gender,
 			phoneNumber);
 		return memberRepository.saveAndFlush(newMember);
 	}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/service/AuthService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/service/AuthService.java
@@ -1,7 +1,5 @@
 package com.nonsoolmate.nonsoolmateServer.domain.auth.service;
 
-import org.springframework.transaction.annotation.Transactional;
-
 import com.nonsoolmate.nonsoolmateServer.domain.auth.controller.dto.request.MemberRequestDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.auth.service.vo.MemberSignUpVO;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
@@ -24,7 +22,6 @@ public abstract class AuthService {
 			.gender(gender).phoneNumber(phoneNumber).build();
 	}
 
-	@Transactional
 	public abstract MemberSignUpVO saveMemberOrLogin(final String platformType, final MemberRequestDTO request);
 
 	protected Member getMember(final PlatformType platformType, final String email) {

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/Member.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/Member.java
@@ -39,6 +39,9 @@ public class Member {
 	@NotNull
 	private PlatformType platformType;
 
+	@NotNull
+	private String platformId;
+
 	@Enumerated(EnumType.STRING)
 	@NotNull
 	private Role role;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/Member.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/Member.java
@@ -15,6 +15,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -22,6 +24,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Table(
+	uniqueConstraints = {
+		@UniqueConstraint(name = "UK_PLATFORM_TYPE_PLATFORM_ID", columnNames = {"platformType", "platformId"})
+	}
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/Member.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/Member.java
@@ -61,12 +61,14 @@ public class Member {
 	private LocalDateTime ticketPreviousPublicationTime;
 
 	@Builder
-	public Member(final String email, final String name, final PlatformType platformType, final Role role,
+	public Member(final String email, final String name, final PlatformType platformType, final String platformId,
+		final Role role,
 		final String birthYear,
 		final String gender, final String phoneNumber) {
 		this.email = email;
 		this.name = name;
 		this.platformType = platformType;
+		this.platformId = platformId;
 		this.role = role;
 		this.birthYear = birthYear;
 		this.gender = gender;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepository.java
@@ -13,7 +13,7 @@ import com.nonsoolmate.nonsoolmateServer.domain.member.entity.enums.PlatformType
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByEmail(String email);
 
-	Optional<Member> findByPlatformTypeAndEmail(PlatformType platformType, String email);
+	Optional<Member> findByPlatformTypeAndPlatformId(PlatformType platformType, String platformId);
 
 	Optional<Member> findByMemberId(Long memberId);
 

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/oauth/service/vo/NaverMemberVO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/external/oauth/service/vo/NaverMemberVO.java
@@ -17,6 +17,7 @@ public class NaverMemberVO {
 	@Getter
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	public static class Response {
+		private String id;
 		private String gender;
 		private String email;
 		private String mobile;


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- fix/#41 -> dev
- closed #41


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- Member 엔티티에 platformId를 추가했습니다 (소셜 플랫폼에서 회원을 구분하는 id)
  - 이에 따라 빌더 패턴도 수정하였습니다
- Member 테이블에 platformType과 platformId의 조합이 중복될 수 없도록 unique 제약조건을 추가했습니다


## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="857" alt="image" src="https://github.com/user-attachments/assets/0bc1fb57-2392-4633-82c3-4a2e44f1a384">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 추상 메서드(AuthService)와 구현 클래스인(NaverAuthService)에서 트랜잭션 어노테이션을 붙이는 것에 대해 고민이 많았는데 구현체의 비지니스 로직에 따라 트랜잭션이 유지되도록 구현 클래스 메서드 위에 명시적으로 옮겨보았는데 어떠신지도 궁금합니다
