### PR TITLE
[TEST] 네이버 소셜 로그인 동시성 테스트 작성

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/error/GlobalExceptionHandler.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/error/GlobalExceptionHandler.java
@@ -28,14 +28,14 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler({BusinessException.class})
 	protected ResponseEntity<ErrorResponse> handleServerException(BusinessException ex) {
-		log.error("🚨BusinessException occurred: {} 🚨", ex);
+		log.error("🚨BusinessException occurred: {} 🚨", ex.getMessage());
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(ErrorResponse.of(CommonErrorType.INTERNAL_SERVER_ERROR));
 	}
 
 	@ExceptionHandler({Exception.class})
 	protected ResponseEntity<ErrorResponse> handleServerException(Exception ex) {
-		log.error("🚨InternalException occurred: {} 🚨", ex);
+		log.error("🚨InternalException occurred: {} 🚨", ex.getMessage());
 		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
 			.body(ErrorResponse.of(CommonErrorType.INTERNAL_SERVER_ERROR));
 	}

--- a/nonsoolmateServer/src/main/resources/application-test.yml
+++ b/nonsoolmateServer/src/main/resources/application-test.yml
@@ -25,14 +25,20 @@ spring:
             host: ${OAUTH2_NAVER_TOKEN_URI_HOST}
             path: ${OAUTH2_NAVER_TOKEN_URI_PATH}
 
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:nonsoolmate-local-db;DATABASE_TO_UPPER=FALSE;mode=mysql  # H2 접속 정보 (전부 소문자로 지정)
+    username: sa
+    password:
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true
         show_sql: true
     open-in-view: false
+    defer-datasource-initialization: true
   data:
     redis:
       host: localhost
@@ -42,15 +48,6 @@ spring:
     console:
       enabled: true
       path: /h2-console
-  sql:
-    init:
-      mode: always
-
-  datasource:
-    driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:nonsoolmate-local-db;DATABASE_TO_UPPER=FALSE;mode=mysql  # H2 접속 정보 (전부 소문자로 지정)
-    username: sa
-    password:
 
 aws-property:
   access-key: ${DEV_AWS_ACCESS_KEY}

--- a/nonsoolmateServer/src/test/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepositoryTest.java
+++ b/nonsoolmateServer/src/test/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepositoryTest.java
@@ -1,6 +1,14 @@
 package com.nonsoolmate.nonsoolmateServer.domain.member.repository;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,7 +57,7 @@ class MemberRepositoryTest {
 	}
 
 	@Test
-	@DisplayName("동일한 회원에 대한 회원가입 요청이 2번 오는 경우 무결성 에러가 발생한다")
+	@DisplayName("동일한 회원에 대한 회원가입 요청이 오는 경우 무결성 에러가 발생한다")
 	void saveMemberDuplicate() {
 		// given
 		Member duplicateMember = Member.builder()
@@ -70,6 +78,52 @@ class MemberRepositoryTest {
 		entityManager.clear();
 
 		assertThat(memberRepository.count()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("동일한 회원에 대한 회원가입 요청이 동시에 오는 경우 무결성 에러가 발생한다")
+	void saveMemberConcurrent() throws InterruptedException {
+		Member duplicateMember = Member.builder()
+			.email("test@example.com")
+			.name("euna")
+			.platformType(PlatformType.NAVER)
+			.role(Role.USER)
+			.platformId("12345")
+			.birthYear("2001")
+			.gender("F")
+			.phoneNumber("010-1234-5678")
+			.build();
+		CountDownLatch latch = new CountDownLatch(2);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+
+		Callable<Void> task = () -> {
+			try {
+				memberRepository.saveAndFlush(duplicateMember);
+			} finally {
+				latch.countDown();
+			}
+			return null;
+		};
+
+		Future<Void> future1 = executor.submit(task);
+		Future<Void> future2 = executor.submit(task);
+
+		latch.await();
+
+		executor.shutdown();
+
+		assertThatThrownBy(() -> {
+			try {
+				future1.get();
+				future2.get();
+			} catch (ExecutionException e) {
+				throw e.getCause();
+			}
+		}).isInstanceOf(DataIntegrityViolationException.class);
+
+		entityManager.clear();
+
+		assertEquals(1, memberRepository.count());
 	}
 
 }

--- a/nonsoolmateServer/src/test/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepositoryTest.java
+++ b/nonsoolmateServer/src/test/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepositoryTest.java
@@ -68,11 +68,11 @@ class MemberRepositoryTest {
 		memberRepository.save(member);
 
 		// when, then
-		assertThatThrownBy(() -> memberRepository.saveAndFlush(duplicateMember))
+		assertThatThrownBy(() -> memberRepository.save(duplicateMember))
 			.isInstanceOf(DataIntegrityViolationException.class);
 		entityManager.clear();
 
-		assertThat(memberRepository.count()).isEqualTo(1);
+		assertEquals(1, memberRepository.count());
 	}
 
 	@Test
@@ -83,7 +83,7 @@ class MemberRepositoryTest {
 
 		Callable<Void> task = () -> {
 			try {
-				memberRepository.saveAndFlush(member);
+				memberRepository.save(member);
 			} finally {
 				latch.countDown();
 			}

--- a/nonsoolmateServer/src/test/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepositoryTest.java
+++ b/nonsoolmateServer/src/test/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepositoryTest.java
@@ -10,7 +10,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,6 +38,7 @@ class MemberRepositoryTest {
 
 	@BeforeEach
 	void setup() {
+		memberRepository.deleteAllInBatch();
 		member = Member.builder()
 			.email("test@example.com")
 			.name("euna")
@@ -49,11 +49,6 @@ class MemberRepositoryTest {
 			.gender("F")
 			.phoneNumber("010-1234-5678")
 			.build();
-	}
-
-	@AfterEach
-	void tearDown() {
-		memberRepository.deleteAllInBatch();
 	}
 
 	@Test
@@ -125,5 +120,4 @@ class MemberRepositoryTest {
 
 		assertEquals(1, memberRepository.count());
 	}
-
 }

--- a/nonsoolmateServer/src/test/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepositoryTest.java
+++ b/nonsoolmateServer/src/test/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepositoryTest.java
@@ -78,22 +78,12 @@ class MemberRepositoryTest {
 	@Test
 	@DisplayName("동일한 회원에 대한 회원가입 요청이 동시에 오는 경우 무결성 에러가 발생한다")
 	void saveMemberConcurrent() throws InterruptedException {
-		Member duplicateMember = Member.builder()
-			.email("test@example.com")
-			.name("euna")
-			.platformType(PlatformType.NAVER)
-			.role(Role.USER)
-			.platformId("12345")
-			.birthYear("2001")
-			.gender("F")
-			.phoneNumber("010-1234-5678")
-			.build();
 		CountDownLatch latch = new CountDownLatch(2);
 		ExecutorService executor = Executors.newFixedThreadPool(2);
 
 		Callable<Void> task = () -> {
 			try {
-				memberRepository.saveAndFlush(duplicateMember);
+				memberRepository.saveAndFlush(member);
 			} finally {
 				latch.countDown();
 			}

--- a/nonsoolmateServer/src/test/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepositoryTest.java
+++ b/nonsoolmateServer/src/test/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,75 @@
+package com.nonsoolmate.nonsoolmateServer.domain.member.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
+import com.nonsoolmate.nonsoolmateServer.domain.member.entity.enums.PlatformType;
+import com.nonsoolmate.nonsoolmateServer.domain.member.entity.enums.Role;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class MemberRepositoryTest {
+	@Autowired
+	private MemberRepository memberRepository;
+
+	private Member member;
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@BeforeEach
+	void setup() {
+		member = Member.builder()
+			.email("test@example.com")
+			.name("euna")
+			.platformType(PlatformType.NAVER)
+			.role(Role.USER)
+			.platformId("12345")
+			.birthYear("2001")
+			.gender("F")
+			.phoneNumber("010-1234-5678")
+			.build();
+	}
+
+	@AfterEach
+	void tearDown() {
+		memberRepository.deleteAllInBatch();
+	}
+
+	@Test
+	@DisplayName("동일한 회원에 대한 회원가입 요청이 2번 오는 경우 무결성 에러가 발생한다")
+	void saveMemberDuplicate() {
+		// given
+		Member duplicateMember = Member.builder()
+			.email("test@example.com")
+			.name("euna")
+			.platformType(PlatformType.NAVER)
+			.role(Role.USER)
+			.platformId("12345")
+			.birthYear("2001")
+			.gender("F")
+			.phoneNumber("010-1234-5678")
+			.build();
+		memberRepository.save(member);
+
+		// when, then
+		assertThatThrownBy(() -> memberRepository.saveAndFlush(duplicateMember))
+			.isInstanceOf(DataIntegrityViolationException.class);
+		entityManager.clear();
+
+		assertThat(memberRepository.count()).isEqualTo(1);
+	}
+
+}


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] TEST

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- test/#68 -> dev
- closed #68

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- repository 단에서 회원가입 로직에 해당하는 함수에 대하여 2가지 테스트케이스를 작성하였습니다
- case1. service 단에서 트랜잭션 실행 시점 차이로 인해 이미 저장된 회원에 대하여 한번 더 테이블에 추가하려는 시도일 경우
- case2. 동시에 테이블에 추가하는 요청이 오는 경우
- 서비스 단 코드도 작성하고 싶었으나 webClient mocking 과정에서 체이닝을 맞추어주는 방식이 memberVO와 tokenVO를 가져오는 과정에서 차이가 있어 어렵더라고요.. 이런 의존성이 많으면 코드가 별로라는 뜻인데, 저희 스프린트 상 현재 이 부분을 집중해서 고치기에는 무리가 있다고 판단되어 repository 단에서의 코드만으로 검증을 했습니다


## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 테스트코드 논메에서 짜니까 ..새롭네요 ^^~ 좋은 의견 많이많이 부탁드림
