### PR TITLE
[FEAT] Member 엔티티 id 타입 변환에 따른 코드 변경

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/dto/response/MemberAuthResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/dto/response/MemberAuthResponseDTO.java
@@ -6,12 +6,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 @Schema(name = "MemberAuthResponseDTO", description = "소셜 로그인 응답 DTO")
-public record MemberAuthResponseDTO(@NotNull @Schema(description = "사용자 id", example = "1") Long memberId,
+public record MemberAuthResponseDTO(@NotNull @Schema(description = "사용자 id", example = "bcdc8ebd") String memberId,
 									@NotNull @Schema(description = "회원가입/로그인 여부", example = "LOGIN 또는 SIGN_UP") AuthType authType,
 									@NotNull @Schema(description = "사용자 이름", example = "류가은") String memberName,
 									@NotNull @Schema(description = "액세스 토큰") String accessToken,
 									@NotNull @Schema(description = "리프레시 토큰") String refreshToken) {
-	public static MemberAuthResponseDTO of(Long memberId, AuthType authType, String memberName, String accessToken,
+	public static MemberAuthResponseDTO of(String memberId, AuthType authType, String memberName, String accessToken,
 		String refreshToken) {
 		return new MemberAuthResponseDTO(memberId, authType, memberName, accessToken, refreshToken);
 	}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/dto/response/MemberReissueResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/controller/dto/response/MemberReissueResponseDTO.java
@@ -4,10 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 @Schema(name = "MemberReissueResponseDTO", description = "리프레시 토큰 재발급 응답 DTO")
-public record MemberReissueResponseDTO(@NotNull @Schema(description = "사용자 id", example = "1") Long memberId,
+public record MemberReissueResponseDTO(@NotNull @Schema(description = "사용자 id", example = "bcdc8ebd") String memberId,
 									   @NotNull @Schema(description = "액세스 토큰") String accessToken,
 									   @NotNull @Schema(description = "리프레시 토큰") String refreshToken) {
-	public static MemberReissueResponseDTO of(Long memberId, String accessToken,
+	public static MemberReissueResponseDTO of(String memberId, String accessToken,
 		String refreshToken) {
 		return new MemberReissueResponseDTO(memberId, accessToken, refreshToken);
 	}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/service/vo/MemberSignUpVO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/auth/service/vo/MemberSignUpVO.java
@@ -8,7 +8,7 @@ import com.nonsoolmate.nonsoolmateServer.external.oauth.service.vo.enums.AuthTyp
 import lombok.Builder;
 
 @Builder
-public record MemberSignUpVO(Long memberId, String email, String name, PlatformType platformType, Role role,
+public record MemberSignUpVO(String memberId, String email, String name, PlatformType platformType, Role role,
 							 String birthYear, String gender, String phoneNumber, AuthType authType) {
 	public static MemberSignUpVO of(Member member, PlatformType platformType, AuthType authtype) {
 		return MemberSignUpVO.builder()

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/Member.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.nonsoolmate.nonsoolmateServer.domain.member.entity;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 import org.hibernate.validator.constraints.Length;
 
@@ -12,8 +13,6 @@ import com.nonsoolmate.nonsoolmateServer.domain.member.exception.MemberException
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
@@ -33,8 +32,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long memberId;
+	private String memberId;
 
 	@NotNull
 	private String email;
@@ -68,10 +66,12 @@ public class Member {
 	private LocalDateTime ticketPreviousPublicationTime;
 
 	@Builder
-	public Member(final String email, final String name, final PlatformType platformType, final String platformId,
+	public Member(final String email, final String name, final PlatformType platformType,
+		final String platformId,
 		final Role role,
 		final String birthYear,
 		final String gender, final String phoneNumber) {
+		this.memberId = createMemberId();
 		this.email = email;
 		this.name = name;
 		this.platformType = platformType;
@@ -87,5 +87,9 @@ public class Member {
 			throw new MemberException(MemberExceptionType.MEMBER_USE_TICKET_FAIL);
 		}
 		this.ticketCount -= 1;
+	}
+
+	private String createMemberId() {
+		return UUID.randomUUID().toString().substring(0, 8);
 	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepository.java
@@ -15,9 +15,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	Optional<Member> findByPlatformTypeAndPlatformId(PlatformType platformType, String platformId);
 
-	Optional<Member> findByMemberId(Long memberId);
+	Optional<Member> findByMemberId(String memberId);
 
-	default Member findByMemberIdOrElseThrow(Long memberId) {
+	default Member findByMemberIdOrElseThrow(String memberId) {
 		return findByMemberId(memberId).orElseThrow(
 			() -> new AuthException(NOT_FOUND_MEMBER));
 	}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/repository/SelectUniversityRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectUniversity/repository/SelectUniversityRepository.java
@@ -17,7 +17,7 @@ public interface SelectUniversityRepository extends JpaRepository<SelectUniversi
 	@Modifying(clearAutomatically = true)
 	@Transactional
 	@Query("DELETE FROM SelectUniversity s WHERE s.member.memberId = :memberId")
-	void deleteAllByMemberId(Long memberId);
+	void deleteAllByMemberId(String memberId);
 
 	@Query("select su from SelectUniversity su where su.member =:member order by su.university.universityName asc, su.university.universityCollege asc")
 	List<SelectUniversity> findAllByMemberOrderByUniversityNameASCUniversityCollegeAsc(Member member);

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/aop/ExecutionLoggingAop.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/aop/ExecutionLoggingAop.java
@@ -28,7 +28,7 @@ public class ExecutionLoggingAop {
 		HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.currentRequestAttributes()).getRequest();
 		RequestMethod httpMethod = RequestMethod.valueOf(request.getMethod());
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-		Long userId = null;
+		String userId = null;
 
 		boolean isNonsoolmateUser = !authentication.getPrincipal().equals("anonymousUser");
 		if (isNonsoolmateUser) {

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/jwt/service/JwtService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/jwt/service/JwtService.java
@@ -87,9 +87,7 @@ public class JwtService {
 		if (!foundRefreshToken.getRefreshToken().equals(refreshToken)) {
 			throw new AuthException(INVALID_REFRESH_TOKEN);
 		}
-
-		Integer o = (Integer)tokenClaims.get(MEMBER_ID_CLAIM);
-		Long memberId = o.longValue();
+		String memberId = tokenClaims.get(MEMBER_ID_CLAIM).toString();
 		String email = (String)tokenClaims.get(EMAIL_CLAIM);
 
 		String newAccessToken = jwtTokenProvider.createAccessToken(email, memberId, accessTokenExpirationPeriod);
@@ -121,8 +119,8 @@ public class JwtService {
 	}
 
 	@Transactional
-	public void updateRefreshToken(Long memberId, String newRefreshToken) {
-		RefreshTokenVO refreshTokenVO = redisTokenRepository.findByMemberId(String.valueOf(memberId)).orElse(null);
+	public void updateRefreshToken(String memberId, String newRefreshToken) {
+		RefreshTokenVO refreshTokenVO = redisTokenRepository.findByMemberId(memberId).orElse(null);
 
 		if (refreshTokenVO != null) {
 			refreshTokenVO.updateRefreshToken(newRefreshToken);

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/jwt/service/JwtTokenProvider.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/jwt/service/JwtTokenProvider.java
@@ -34,7 +34,7 @@ public class JwtTokenProvider {
 		this.objectMapper = objectMapper;
 	}
 
-	public String createAccessToken(String email, Long memberId, Long expirationTime) {
+	public String createAccessToken(String email, String memberId, Long expirationTime) {
 		Date now = new Date();
 
 		return Jwts.builder()
@@ -47,7 +47,7 @@ public class JwtTokenProvider {
 			.compact();
 	}
 
-	public String createRefreshToken(Long memberId, Long expirationTime) {
+	public String createRefreshToken(String memberId, Long expirationTime) {
 		Date now = new Date();
 
 		return Jwts.builder()

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/security/service/MemberAuthService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/security/service/MemberAuthService.java
@@ -18,7 +18,7 @@ public class MemberAuthService implements UserDetailsService {
 
 	@Override
 	public UserDetails loadUserByUsername(String memberId) throws UsernameNotFoundException {
-		Member member = memberRepository.findByMemberIdOrElseThrow(Long.parseLong(memberId));
+		Member member = memberRepository.findByMemberIdOrElseThrow(memberId);
 
 		return new CustomAuthUser(member, member.getRole());
 	}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#78 -> dev
- closed #78

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- member 엔티티의 id 필드를 String 타입으로 수정하고 UUID로 id를 자동 지정하도록 수정했습니다
- member_id를 Long으로 받는 클래스 또는 함수들의 파라미터 타입을 모두 변경해주었습니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="1124" alt="image" src="https://github.com/user-attachments/assets/bfae5bcd-603c-484b-b08e-d3264059f26e">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- UUID 중 8개만 받아와서 생성하도록 구현했는데 어떠신지 궁금합니다! 괜찮으시면 Order 엔티티도 해당 방식으로 수정하겠습니다~
 - 단, 이럴 경우 중복되는 경우에 대해서는 서비스 단에서 에러 발생 시 다시 엔티티를 생성하도록 시도해야 하긴합니다!