### PR TITLE
feat: 쿠폰 관련 로직 구현

### DIFF
--- a/nonsoolmateServer/build.gradle
+++ b/nonsoolmateServer/build.gradle
@@ -82,6 +82,12 @@ dependencies {
     // tsid
     implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.7.6'
 
+    //QueryDSL
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 }
 
 tasks.named('test') {

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/common/random/CustomRandom.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/common/random/CustomRandom.java
@@ -1,0 +1,5 @@
+package com.nonsoolmate.nonsoolmateServer.domain.common.random;
+
+public interface CustomRandom {
+	String generateRandomValue();
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/common/random/MockRandom.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/common/random/MockRandom.java
@@ -1,0 +1,14 @@
+package com.nonsoolmate.nonsoolmateServer.domain.common.random;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile("test")
+public class MockRandom implements CustomRandom {
+
+	@Override
+	public String generateRandomValue() {
+		return "test-random-value";
+	}
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/common/random/RealRandom.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/common/random/RealRandom.java
@@ -1,0 +1,15 @@
+package com.nonsoolmate.nonsoolmateServer.domain.common.random;
+
+import java.util.UUID;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile({"local", "dev", "prod"})
+public class RealRandom implements CustomRandom {
+	@Override
+	public String generateRandomValue() {
+		return UUID.randomUUID().toString().substring(0, 12);
+	}
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/common/random/RealRandom.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/common/random/RealRandom.java
@@ -10,6 +10,6 @@ import org.springframework.stereotype.Component;
 public class RealRandom implements CustomRandom {
 	@Override
 	public String generateRandomValue() {
-		return UUID.randomUUID().toString().substring(0, 12);
+		return UUID.randomUUID().toString().substring(0, 13);
 	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/controller/CouponApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/controller/CouponApi.java
@@ -1,0 +1,31 @@
+package com.nonsoolmate.nonsoolmateServer.domain.coupon.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.controller.dto.request.IssueCouponRequestDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.controller.dto.response.GetCouponsResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.request.RegisterCouponRequestDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
+import com.nonsoolmate.nonsoolmateServer.global.security.AuthUser;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+
+@Tag(name = "Coupon", description = "쿠폰과 관련된 API")
+public interface CouponApi {
+	/**
+	 * @breif: 쿠폰 발행 API
+	 * @note: 서버 내에서 사용하는 API 입니다.
+	 *
+	 */
+	ResponseEntity<Void> issueCoupon(@RequestBody @Valid IssueCouponRequestDTO requestDTO);
+
+	@Operation(summary = "쿠폰 목록 조회", description = "사용자가 가지고 있는 쿠폰 목록을 조회합니다.")
+	ResponseEntity<GetCouponsResponseDTO> getCoupons(@AuthUser Member member);
+
+	@Operation(summary = "쿠폰 등록", description = "쿠폰을 등록합니다.")
+	ResponseEntity<Void> registerCoupon(@RequestBody @Valid RegisterCouponRequestDTO requestDTO,
+		@AuthUser Member member);
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/controller/CouponController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/controller/CouponController.java
@@ -1,0 +1,52 @@
+package com.nonsoolmate.nonsoolmateServer.domain.coupon.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.controller.dto.request.IssueCouponRequestDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.controller.dto.response.GetCouponsResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.service.CouponService;
+import com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.request.RegisterCouponRequestDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
+import com.nonsoolmate.nonsoolmateServer.global.security.AuthUser;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/coupon")
+public class CouponController implements CouponApi {
+	private final CouponService couponService;
+
+	@Override
+	@PostMapping("/issue")
+	public ResponseEntity<Void> issueCoupon(@RequestBody @Valid IssueCouponRequestDTO requestDTO) {
+
+		couponService.issueCoupon(requestDTO);
+		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+
+	@Override
+	@GetMapping
+	public ResponseEntity<GetCouponsResponseDTO> getCoupons(@AuthUser Member member) {
+		GetCouponsResponseDTO responseDTO = couponService.getCoupons(member);
+
+		return ResponseEntity.ok().body(responseDTO);
+	}
+
+	@Override
+	@PostMapping
+	public ResponseEntity<Void> registerCoupon(
+		@RequestBody @Valid RegisterCouponRequestDTO requestDTO,
+		@AuthUser Member member) {
+		couponService.registerCoupon(requestDTO, member);
+
+		return ResponseEntity.status(HttpStatus.CREATED).build();
+	}
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/controller/dto/request/IssueCouponRequestDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/controller/dto/request/IssueCouponRequestDTO.java
@@ -14,6 +14,9 @@ import lombok.RequiredArgsConstructor;
 public class IssueCouponRequestDTO{
 
 	@NotNull
+	private final String secretValue;
+
+	@NotNull
 	private final String couponName;
 	private final String couponDescription;
 	private final String couponImageUrl;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/controller/dto/request/IssueCouponRequestDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/controller/dto/request/IssueCouponRequestDTO.java
@@ -1,0 +1,43 @@
+package com.nonsoolmate.nonsoolmateServer.domain.coupon.controller.dto.request;
+
+import java.time.LocalDateTime;
+
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.entity.Coupon;
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.entity.enums.CouponType;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public class IssueCouponRequestDTO{
+
+	@NotNull
+	private final String couponName;
+	private final String couponDescription;
+	private final String couponImageUrl;
+	private final String couponNumber;
+	@NotNull
+	private final CouponType couponType;
+	private final int discountRate;
+	private final int discountAmount;
+	private final int ticketCount;
+	private final LocalDateTime validStartDate;
+	private final LocalDateTime validEndDate;
+
+	public Coupon toEntity(String requestCouponNumber){
+		return Coupon.builder()
+			.couponName(couponName)
+			.couponDescription(couponDescription)
+			.couponImageUrl(couponImageUrl)
+			.couponNumber(requestCouponNumber)
+			.couponType(couponType)
+			.discountRate(discountRate)
+			.discountAmount(discountAmount)
+			.ticketCount(ticketCount)
+			.validStartDate(validStartDate)
+			.validEndDate(validEndDate)
+			.build();
+	}
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/controller/dto/response/GetCouponResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/controller/dto/response/GetCouponResponseDTO.java
@@ -1,0 +1,61 @@
+package com.nonsoolmate.nonsoolmateServer.domain.coupon.controller.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.entity.enums.CouponType;
+import com.querydsl.core.annotations.QueryProjection;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Schema(name = "GetCouponResponseDTO", description = "쿠폰 조회 DTO")
+@Getter
+public class GetCouponResponseDTO {
+
+	@Schema(description = "쿠폰 이름", example = "쿠폰 이름입니다.")
+	private final String couponName;
+
+	@Schema(description = "쿠폰 상세 설명", example = "쿠폰 설명입니다.")
+	private final String couponDescription;
+
+	@Schema(description = "쿠폰 이미지 url", example = "[url] 형식")
+	private final String couponImageUrl;
+
+	@Schema(description = "쿠폰 타입, </br> RATE, AMOUNT, EDIT_TICKET 중에 하나입니다.", example = "RATE")
+	private final CouponType couponType;
+
+	@Schema(description = "RATE 일 경우 할인율", example = "20")
+	private final int discountRate;
+
+	@Schema(description = "AMOUNT 일 경우 할인금액", example = "30000")
+	private final int discountAmount;
+
+	@Schema(description = "EDIT_TICKET 일 경우 증정 첨삭권 갯수", example = "10")
+	private final int ticketCount;
+
+	@Schema(description = "쿠폰 유효 시작기간", example = "2024-08-22T05:16:44.051Z")
+	private final LocalDateTime validStartDate;
+
+	@Schema(description = "쿠폰 유효 종료기간", example = "2024-11-13T05:16:44.051Z")
+	private final LocalDateTime validEndDate;
+
+	@Schema(description = "쿠폰 사용여부", example = "true")
+	private final Boolean isUsed;
+
+	@QueryProjection
+	public GetCouponResponseDTO(String couponName, String couponDescription, String couponImageUrl,
+		CouponType couponType,
+		int discountRate, int discountAmount, int ticketCount, LocalDateTime validStartDate, LocalDateTime validEndDate,
+		Boolean isUsed) {
+		this.couponName = couponName;
+		this.couponDescription = couponDescription;
+		this.couponImageUrl = couponImageUrl;
+		this.couponType = couponType;
+		this.discountRate = discountRate;
+		this.discountAmount = discountAmount;
+		this.ticketCount = ticketCount;
+		this.validStartDate = validStartDate;
+		this.validEndDate = validEndDate;
+		this.isUsed = isUsed;
+	}
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/controller/dto/response/GetCouponsResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/controller/dto/response/GetCouponsResponseDTO.java
@@ -1,0 +1,15 @@
+package com.nonsoolmate.nonsoolmateServer.domain.coupon.controller.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "GetCouponsResponseDTO", description = "쿠폰 목록 조회 DTO")
+public record GetCouponsResponseDTO(
+	@Schema(description = "쿠폰 조회 DTO", example = "")
+	List<GetCouponResponseDTO> coupons
+) {
+	public static GetCouponsResponseDTO of(List<GetCouponResponseDTO> coupons){
+		return new GetCouponsResponseDTO(coupons);
+	}
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/exception/CouponException.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/exception/CouponException.java
@@ -1,0 +1,10 @@
+package com.nonsoolmate.nonsoolmateServer.domain.coupon.exception;
+
+import com.nonsoolmate.nonsoolmateServer.global.error.exception.ClientException;
+import com.nonsoolmate.nonsoolmateServer.global.error.exception.ExceptionType;
+
+public class CouponException extends ClientException {
+	public CouponException(ExceptionType exceptionType) {
+		super(exceptionType);
+	}
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/exception/CouponExceptionType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/exception/CouponExceptionType.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum CouponExceptionType implements ExceptionType {
+	INVALID_COUPON_ISSUE(HttpStatus.BAD_REQUEST, "올바르지 않는 요청입니다."),
 	NOT_FOUND_COUPON(HttpStatus.NOT_FOUND, "유효한 쿠폰을 찾을 수 없습니다.");
 
 	private final HttpStatus status;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/exception/CouponExceptionType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/exception/CouponExceptionType.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum CouponExceptionType implements ExceptionType {
+	INVALID_COUPON_REGISTER(HttpStatus.BAD_REQUEST, "이미 등록된 쿠폰입니다."),
 	INVALID_COUPON_ISSUE(HttpStatus.BAD_REQUEST, "올바르지 않는 요청입니다."),
 	NOT_FOUND_COUPON(HttpStatus.NOT_FOUND, "유효한 쿠폰을 찾을 수 없습니다.");
 

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/exception/CouponExceptionType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/exception/CouponExceptionType.java
@@ -1,0 +1,26 @@
+package com.nonsoolmate.nonsoolmateServer.domain.coupon.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.nonsoolmate.nonsoolmateServer.global.error.exception.ExceptionType;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum CouponExceptionType implements ExceptionType {
+	NOT_FOUND_COUPON(HttpStatus.NOT_FOUND, "유효한 쿠폰을 찾을 수 없습니다.");
+
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public HttpStatus status() {
+		return this.status;
+	}
+
+	@Override
+	public String message() {
+		return this.message;
+	}
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/repository/CouponRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/repository/CouponRepository.java
@@ -1,0 +1,19 @@
+package com.nonsoolmate.nonsoolmateServer.domain.coupon.repository;
+
+import static com.nonsoolmate.nonsoolmateServer.domain.coupon.exception.CouponExceptionType.*;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.entity.Coupon;
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.exception.CouponException;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+	Optional<Coupon> findByCouponNumber(String couponNumber);
+
+	default Coupon findByCouponNumberOrThrow(String couponNumber){
+		return findByCouponNumber(couponNumber)
+			.orElseThrow(() -> new CouponException(NOT_FOUND_COUPON));
+	}
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/service/CouponService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/service/CouponService.java
@@ -1,7 +1,10 @@
 package com.nonsoolmate.nonsoolmateServer.domain.coupon.service;
 
+import static com.nonsoolmate.nonsoolmateServer.domain.coupon.exception.CouponExceptionType.*;
+
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,6 +13,7 @@ import com.nonsoolmate.nonsoolmateServer.domain.coupon.controller.dto.request.Is
 import com.nonsoolmate.nonsoolmateServer.domain.coupon.controller.dto.response.GetCouponResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.coupon.controller.dto.response.GetCouponsResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.coupon.entity.Coupon;
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.exception.CouponException;
 import com.nonsoolmate.nonsoolmateServer.domain.coupon.repository.CouponRepository;
 import com.nonsoolmate.nonsoolmateServer.domain.couponMember.entity.CouponMember;
 import com.nonsoolmate.nonsoolmateServer.domain.couponMember.repository.CouponMemberRepository;
@@ -27,8 +31,15 @@ public class CouponService {
 
 	private final CustomRandom customRandom;
 
+	@Value("${coupon.secret}")
+	private String couponSecretValue;
+
 	@Transactional
 	public void issueCoupon(IssueCouponRequestDTO requestDTO){
+		if(requestDTO.getSecretValue().equals(couponSecretValue)){
+			throw new CouponException(INVALID_COUPON_ISSUE);
+		}
+
 		String couponNumber = requestDTO.getCouponNumber();
 
 		if(couponNumber == null){

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/service/CouponService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/service/CouponService.java
@@ -1,0 +1,65 @@
+package com.nonsoolmate.nonsoolmateServer.domain.coupon.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nonsoolmate.nonsoolmateServer.domain.common.random.CustomRandom;
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.controller.dto.request.IssueCouponRequestDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.controller.dto.response.GetCouponResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.controller.dto.response.GetCouponsResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.entity.Coupon;
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.repository.CouponRepository;
+import com.nonsoolmate.nonsoolmateServer.domain.couponMember.entity.CouponMember;
+import com.nonsoolmate.nonsoolmateServer.domain.couponMember.repository.CouponMemberRepository;
+import com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.request.RegisterCouponRequestDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CouponService {
+	private final CouponRepository couponRepository;
+	private final CouponMemberRepository couponMemberRepository;
+
+	private final CustomRandom customRandom;
+
+	@Transactional
+	public void issueCoupon(IssueCouponRequestDTO requestDTO){
+		String couponNumber = requestDTO.getCouponNumber();
+
+		if(couponNumber == null){
+			couponNumber = customRandom.generateRandomValue();
+		}
+
+		Coupon coupon = requestDTO.toEntity(couponNumber);
+		couponRepository.save(coupon);
+	}
+
+
+	public GetCouponsResponseDTO getCoupons(Member member) {
+		List<GetCouponResponseDTO> responseDTOs = couponMemberRepository.findAllByMemberIdWithCoupon(
+			member.getMemberId());
+
+		return GetCouponsResponseDTO.of(responseDTOs);
+	}
+
+	@Transactional
+	public void registerCoupon(RegisterCouponRequestDTO requestDTO, Member member) {
+		Coupon coupon = couponRepository.findByCouponNumberOrThrow(requestDTO.couponNumber());
+
+		CouponMember couponMember = createCouponMember(member, coupon);
+		couponMemberRepository.save(couponMember);
+	}
+
+	private CouponMember createCouponMember(Member member, Coupon coupon) {
+		return CouponMember.builder()
+			.couponId(coupon.getCouponId())
+			.memberId(member.getMemberId())
+			.isUsed(false)
+			.build();
+	}
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/couponMember/entity/CouponMember.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/couponMember/entity/CouponMember.java
@@ -22,7 +22,7 @@ public class CouponMember extends BaseTimeEntity {
 	private Long couponMemberId;
 
 	@NotNull
-	private Long memberId;
+	private String memberId;
 
 	@NotNull
 	private Long couponId;
@@ -31,7 +31,7 @@ public class CouponMember extends BaseTimeEntity {
 	private Boolean isUsed;
 
 	@Builder
-	private CouponMember(Long memberId, Long couponId, Boolean isUsed) {
+	private CouponMember(String memberId, Long couponId, Boolean isUsed) {
 		this.memberId = memberId;
 		this.couponId = couponId;
 		this.isUsed = isUsed;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/couponMember/repository/CouponMemberCustomRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/couponMember/repository/CouponMemberCustomRepository.java
@@ -1,0 +1,9 @@
+package com.nonsoolmate.nonsoolmateServer.domain.couponMember.repository;
+
+import java.util.List;
+
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.controller.dto.response.GetCouponResponseDTO;
+
+public interface CouponMemberCustomRepository {
+	List<GetCouponResponseDTO> findAllByMemberIdWithCoupon(String memberId);
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/couponMember/repository/CouponMemberCustomRepositoryImpl.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/couponMember/repository/CouponMemberCustomRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.nonsoolmate.nonsoolmateServer.domain.couponMember.repository;
+
+import static com.nonsoolmate.nonsoolmateServer.domain.coupon.entity.QCoupon.*;
+import static com.nonsoolmate.nonsoolmateServer.domain.couponMember.entity.QCouponMember.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.controller.dto.response.GetCouponResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.coupon.controller.dto.response.QGetCouponResponseDTO;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CouponMemberCustomRepositoryImpl implements CouponMemberCustomRepository {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<GetCouponResponseDTO> findAllByMemberIdWithCoupon(String memberId) {
+		return queryFactory
+			.select(new QGetCouponResponseDTO(
+				coupon.couponName,
+				coupon.couponDescription,
+				coupon.couponImageUrl,
+				coupon.couponType,
+				coupon.discountRate,
+				coupon.discountAmount,
+				coupon.ticketCount,
+				coupon.validStartDate,
+				coupon.validEndDate,
+				couponMember.isUsed))
+			.from(couponMember)
+			.where(couponMember.memberId.eq(memberId))
+			.leftJoin(coupon).on(couponMember.couponId.eq(coupon.couponId))
+			.fetch();
+	}
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/couponMember/repository/CouponMemberRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/couponMember/repository/CouponMemberRepository.java
@@ -1,0 +1,10 @@
+package com.nonsoolmate.nonsoolmateServer.domain.couponMember.repository;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.nonsoolmate.nonsoolmateServer.domain.couponMember.entity.CouponMember;
+
+public interface CouponMemberRepository extends JpaRepository<CouponMember, Long>, CouponMemberCustomRepository {
+
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/couponMember/repository/CouponMemberRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/couponMember/repository/CouponMemberRepository.java
@@ -1,10 +1,12 @@
 package com.nonsoolmate.nonsoolmateServer.domain.couponMember.repository;
 
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.nonsoolmate.nonsoolmateServer.domain.couponMember.entity.CouponMember;
 
 public interface CouponMemberRepository extends JpaRepository<CouponMember, Long>, CouponMemberCustomRepository {
-
+	Optional<CouponMember> findByCouponId(Long couponId);
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/dto/request/RegisterCouponRequestDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/dto/request/RegisterCouponRequestDTO.java
@@ -1,0 +1,12 @@
+package com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(name = "RegisterCouponRequestDTO", description = "쿠폰 등록 요청 DTO")
+public record RegisterCouponRequestDTO(
+	@NotNull
+	@Schema(description = "쿠폰 번호", example = "1234-5678-abcd")
+	String couponNumber
+) {
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/jwt/service/JwtService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/jwt/service/JwtService.java
@@ -98,7 +98,7 @@ public class JwtService {
 		return MemberReissueResponseDTO.of(memberId, newAccessToken, newRefreshToken);
 	}
 
-	public Long extractMemberIdFromAccessToken(final String atk) throws JsonProcessingException {
+	public String extractMemberIdFromAccessToken(final String atk) throws JsonProcessingException {
 		Claims tokenClaims = jwtTokenProvider.getTokenClaims(atk);
 		return jwtTokenProvider.getMemberIdFromClaim(tokenClaims, AUTH_USER);
 	}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/jwt/service/JwtTokenProvider.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/jwt/service/JwtTokenProvider.java
@@ -74,8 +74,8 @@ public class JwtTokenProvider {
 		return claims;
 	}
 
-	public Long getMemberIdFromClaim(Claims claims, String infoName) throws JsonProcessingException {
+	public String getMemberIdFromClaim(Claims claims, String infoName) throws JsonProcessingException {
 
-		return claims.get(infoName, Long.class);
+		return claims.get(infoName, String.class);
 	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/querydsl/config/QuerydslConfig.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/querydsl/config/QuerydslConfig.java
@@ -1,0 +1,21 @@
+package com.nonsoolmate.nonsoolmateServer.global.querydsl.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/security/filter/JwtAuthenticationFilter.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/global/security/filter/JwtAuthenticationFilter.java
@@ -64,8 +64,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		try {
 			jwtService.validateToken(authorizationAccessToken);
 
-			Long memberId = jwtService.extractMemberIdFromAccessToken(authorizationAccessToken);
-			UserDetails userDetails = memberAuthService.loadUserByUsername(String.valueOf(memberId));
+			String memberId = jwtService.extractMemberIdFromAccessToken(authorizationAccessToken);
+			UserDetails userDetails = memberAuthService.loadUserByUsername(memberId);
 
 			Authentication authentication
 				= new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());

--- a/nonsoolmateServer/src/main/resources/application-dev.yml
+++ b/nonsoolmateServer/src/main/resources/application-dev.yml
@@ -73,3 +73,6 @@ payment:
   toss:
     api-secret-key: ${DEV_PAYMENT_API_KEY}
     widget-secret-key: ${DEV_PAYMENT_WIDGET_KEY}
+
+coupon:
+  secret: ${COUPON_SECRET}

--- a/nonsoolmateServer/src/main/resources/application-local.yml
+++ b/nonsoolmateServer/src/main/resources/application-local.yml
@@ -78,3 +78,6 @@ payment:
   toss:
     api-secret-key: ${DEV_PAYMENT_API_KEY}
     widget-secret-key: ${DEV_PAYMENT_WIDGET_KEY}
+
+coupon:
+  secret: ${COUPON_SECRET}

--- a/nonsoolmateServer/src/main/resources/application-prod.yml
+++ b/nonsoolmateServer/src/main/resources/application-prod.yml
@@ -77,3 +77,6 @@ payment:
   toss:
     api-secret-key: ${PROD_PAYMENT_API_KEY}
     widget-secret-key: ${PROD_PAYMENT_WIDGET_KEY}
+
+coupon:
+  secret: ${COUPON_SECRET}

--- a/nonsoolmateServer/src/main/resources/application-test.yml
+++ b/nonsoolmateServer/src/main/resources/application-test.yml
@@ -78,3 +78,6 @@ payment:
   toss:
     api-secret-key: ${DEV_PAYMENT_API_KEY}
     widget-secret-key: ${DEV_PAYMENT_WIDGET_KEY}
+
+coupon:
+  secret: ${COUPON_SECRET}

--- a/nonsoolmateServer/src/test/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepositoryTest.java
+++ b/nonsoolmateServer/src/test/java/com/nonsoolmate/nonsoolmateServer/domain/member/repository/MemberRepositoryTest.java
@@ -15,18 +15,21 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.enums.PlatformType;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.enums.Role;
+import com.nonsoolmate.nonsoolmateServer.global.querydsl.config.QuerydslConfig;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 
 @DataJpaTest
 @ActiveProfiles("test")
+@Import(QuerydslConfig.class)
 class MemberRepositoryTest {
 	@Autowired
 	private MemberRepository memberRepository;


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
feat/#81
closed #81 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- API 1개당 PR 1개를 올릴려고 했는데.. 기능이 간단해서.. 한 번에 올렸습니다...!
<br></br>
- 구현된 API는 다음과 같습니다.
- 쿠폰 발행 API (FE에서 사용 X)
- 쿠폰 조회 API
- 쿠폰 등록 API

관련 yml 수정도 진행하겠습니다!

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

### 쿠폰 발행 API : 정상 요청
<img width="812" alt="스크린샷 2024-08-22 오후 4 17 11" src="https://github.com/user-attachments/assets/65a7e417-b4e2-4344-bfe7-156a4e7fafb7">
<img width="1157" alt="스크린샷 2024-08-22 오후 4 17 33" src="https://github.com/user-attachments/assets/21535071-6697-4f6e-8bf8-d8a405453d7b">


### 쿠폰 발행 API : 시크릿값 틀린 경우
<img width="822" alt="스크린샷 2024-08-22 오후 4 16 39" src="https://github.com/user-attachments/assets/c132892c-f08f-479f-93c1-19b9252f71c0">

### 쿠폰 등록 API : 정상 요청
<img width="783" alt="스크린샷 2024-08-22 오후 4 25 06" src="https://github.com/user-attachments/assets/e0c701d2-815e-4af0-9725-c3ccb0c64d8d">
<img width="618" alt="스크린샷 2024-08-22 오후 4 25 20" src="https://github.com/user-attachments/assets/dad9869d-6760-41ed-b5cd-5e84f44b0cc7">


### 쿠폰 등록 API : 틀린 쿠폰 번호일 경우
<img width="832" alt="스크린샷 2024-08-22 오후 4 22 06" src="https://github.com/user-attachments/assets/d9bb421a-2d08-41c1-9b36-e948a07699a7">

### 쿠폰 등록 API : 이미 등록한 경우
<img width="830" alt="스크린샷 2024-08-22 오후 4 25 44" src="https://github.com/user-attachments/assets/287d0737-a706-4132-849e-bf0e95bafe5c">


### 쿠폰 조회 API 
<img width="862" alt="스크린샷 2024-08-22 오후 4 25 56" src="https://github.com/user-attachments/assets/38da745d-953b-4181-af7e-b8d189d75f5a">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
### CustomRandom
- `LocaldateTime.now()` 나 `Random` 과 같이 통제할 수 없는 객체들은 Testability 를 낮추기 때문에 고민했는데요!
- 그래서 인터페이스를 사용해서 DI 방식으로 적용해봤습니다! 실제 비즈니스 로직에서는 RealRandom, 테스트코드 돌아갈 때는 MockRandom이 돌아가도록 설정해뒀습니다.

### querydsl
- 쿠폰 목록 조회할때, 프로젝션으로 구현하면 깔끔할 것 같아서 구현해봤습니다!
- JPQL 사용하려다가 `type-safety`한 `querydsl`를 선호해서 그렇게 구현해봤습니다