### PR TITLE
[FEAT] Membership, TargetUniversity 엔티티 구현

### DIFF
--- a/nonsoolmateServer/.gitignore
+++ b/nonsoolmateServer/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+generated/
 
 ### STS ###
 .apt_generated

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/service/ExamRecordService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/service/ExamRecordService.java
@@ -107,7 +107,7 @@ public class ExamRecordService {
 
 	private void decreaseMemberTicketCount(final Member member) {
 		try {
-			member.decreaseTicket();
+			member.decreaseReviewTicket();
 			memberRepository.save(member);
 		} catch (MemberException e) {
 			throw e;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/Member.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/Member.java
@@ -1,7 +1,5 @@
 package com.nonsoolmate.nonsoolmateServer.domain.member.entity;
 
-import java.time.LocalDateTime;
-
 import org.hibernate.validator.constraints.Length;
 
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.enums.PlatformType;
@@ -62,9 +60,9 @@ public class Member {
 	@Length(max = 13)
 	private String phoneNumber;
 
-	private int ticketCount;
+	private int reviewTicketCount;
 
-	private LocalDateTime ticketPreviousPublicationTime;
+	private int reReviewTicketCount;
 
 	@Builder
 	public Member(final String email, final String name, final PlatformType platformType,
@@ -82,10 +80,10 @@ public class Member {
 		this.phoneNumber = phoneNumber;
 	}
 
-	public void decreaseTicket() {
-		if (this.ticketCount <= 0) {
+	public void decreaseReviewTicket() {
+		if (this.reviewTicketCount <= 0) {
 			throw new MemberException(MemberExceptionType.MEMBER_USE_TICKET_FAIL);
 		}
-		this.ticketCount -= 1;
+		this.reviewTicketCount -= 1;
 	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/Membership.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/Membership.java
@@ -1,0 +1,36 @@
+package com.nonsoolmate.nonsoolmateServer.domain.member.entity;
+
+import java.time.LocalDateTime;
+
+import com.nonsoolmate.nonsoolmateServer.domain.common.BaseTimeEntity;
+import com.nonsoolmate.nonsoolmateServer.domain.member.entity.enums.MembershipStatus;
+import com.nonsoolmate.nonsoolmateServer.domain.member.entity.enums.MembershipType;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Membership extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	Long membershipId;
+
+	@OneToOne
+	Member member;
+
+	MembershipType membershipType;
+
+	LocalDateTime startDate;
+
+	LocalDateTime endDate;
+
+	MembershipStatus status;
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/enums/MembershipStatus.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/enums/MembershipStatus.java
@@ -1,0 +1,5 @@
+package com.nonsoolmate.nonsoolmateServer.domain.member.entity.enums;
+
+public enum MembershipStatus {
+	IN_PROGRESS, TERMINATED;
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/enums/MembershipType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/enums/MembershipType.java
@@ -1,0 +1,5 @@
+package com.nonsoolmate.nonsoolmateServer.domain.member.entity.enums;
+
+public enum MembershipType {
+	BASIC, PREMIUM;
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/service/MemberService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/service/MemberService.java
@@ -22,7 +22,7 @@ public class MemberService {
 	}
 
 	public TicketResponseDTO getTicket(final Member member) {
-		return TicketResponseDTO.of(member.getName(), member.getTicketCount());
+		return TicketResponseDTO.of(member.getName(), member.getReviewTicketCount());
 	}
 
 	public ProfileResponseDTO getProfile(final Member member) {

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/targetUniversity/entity/TargetUniversity.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/targetUniversity/entity/TargetUniversity.java
@@ -1,0 +1,28 @@
+package com.nonsoolmate.nonsoolmateServer.domain.targetUniversity.entity;
+
+import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
+import com.nonsoolmate.nonsoolmateServer.domain.university.entity.University;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TargetUniversity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	Long targetUniversityId;
+
+	@ManyToOne
+	University university;
+
+	@ManyToOne
+	Member member;
+}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#88 -> dev
- closed #88 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- Membership : Member -> 1:1 (Member 패키지에 포함)
- Member : TargetUnviersity -> 1:N
- TagetUniversity : University -> N:1
- TargetUniversity 패키지 분리
- Member 엔티티에 첨삭권과 재첨삭권 필드 분리 및 관련 함수 이름 변경

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
