### PR TITLE
[FEAT] 사용자가 등록한 쿠폰 조회 API에서 사용하는 dto에 couponMemberId 추가

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/controller/dto/response/GetCouponResponseDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/coupon/controller/dto/response/GetCouponResponseDTO.java
@@ -11,6 +11,8 @@ import lombok.Getter;
 @Schema(name = "GetCouponResponseDTO", description = "쿠폰 조회 DTO")
 @Getter
 public class GetCouponResponseDTO {
+	@Schema(description = "사용자가 등록한 coupon의 id", example = "1")
+	private final Long couponMemberId;
 
 	@Schema(description = "쿠폰 이름", example = "쿠폰 이름입니다.")
 	private final String couponName;
@@ -43,10 +45,11 @@ public class GetCouponResponseDTO {
 	private final Boolean isUsed;
 
 	@QueryProjection
-	public GetCouponResponseDTO(String couponName, String couponDescription, String couponImageUrl,
+	public GetCouponResponseDTO(Long couponMemberId, String couponName, String couponDescription, String couponImageUrl,
 		CouponType couponType,
 		int discountRate, int discountAmount, int ticketCount, LocalDateTime validStartDate, LocalDateTime validEndDate,
 		Boolean isUsed) {
+		this.couponMemberId = couponMemberId;
 		this.couponName = couponName;
 		this.couponDescription = couponDescription;
 		this.couponImageUrl = couponImageUrl;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/couponMember/repository/CouponMemberCustomRepositoryImpl.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/couponMember/repository/CouponMemberCustomRepositoryImpl.java
@@ -22,6 +22,7 @@ public class CouponMemberCustomRepositoryImpl implements CouponMemberCustomRepos
 	public List<GetCouponResponseDTO> findAllByMemberIdWithCoupon(String memberId) {
 		return queryFactory
 			.select(new QGetCouponResponseDTO(
+				couponMember.couponMemberId,
 				coupon.couponName,
 				coupon.couponDescription,
 				coupon.couponImageUrl,

--- a/nonsoolmateServer/src/main/resources/application-local.yml
+++ b/nonsoolmateServer/src/main/resources/application-local.yml
@@ -38,7 +38,7 @@ spring:
         format_sql: true
         show_sql: true
     open-in-view: false
-  #    defer-datasource-initialization: true
+    defer-datasource-initialization: true
   data:
     redis:
       host: localhost


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- closed #90


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 쿠폰 사용 시 가격 검증을 위해 사용자가 어떤 쿠폰을 사용하는지 알아야하기 때문에 CouponMember 테이블에서 사용되는 id를 dto에 추가했습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 본인이 등록한 쿠폰 2개 (쿠폰 id는 1로 동일)
<img width="1567" alt="스크린샷 2024-08-29 오후 4 57 47" src="https://github.com/user-attachments/assets/04e6bdef-3f3f-4b3c-9bf6-6583db50cc85">

- dto에 전달되는 id는 couponMember에 저장되어 있는 열의 id
<img width="1124" alt="스크린샷 2024-08-29 오후 4 57 44" src="https://github.com/user-attachments/assets/1000e26e-ad50-48ec-8d4a-557a08d88810">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 쿠폰 로직을 다시 살펴보니 조회, 등록 같은 경우 CouponMember 도메인에서 이루어지는 로직이라는 생각이 드는데 coupon 도메인에 대부분의 코드가 작성되어 있더라고요?! getCoupons, registerCoupons는 CouponMember를 조회하거나 등록한다는 의미가 강한 것 같은데 service를 분리하시는건 어떤지 궁금합니다~ PR 날려주셨을 때 확인했어야 하는 부분인데 뒤늦게 리뷰 남겨 죄송합니다!
- 그리고 getCoupons에서 사용자의 쿠폰을 조회한다는 느낌의 메서드명으로 변경하는건 어떤지.. ByMember를 붙인다던가 등등.. 궁금합니다 ㅎ