### PR TITLE
[FEAT] 단과 대학별 시험지 리스트 조회에 재첨삭 플로우 구현

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/entity/ExamRecord.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/entity/ExamRecord.java
@@ -59,11 +59,12 @@ public class ExamRecord {
 	private String examRecordResultFileName;
 
 	@Builder
-	public ExamRecord(final Exam exam, final Member member, final EditingType editingType,
+	public ExamRecord(final Exam exam, final Member member, final ExamResultStatus examResultStatus,
+		final EditingType editingType,
 		final int timeTakeExam, final String examRecordSheetFileName) {
 		this.exam = exam;
 		this.member = member;
-		this.examResultStatus = ExamResultStatus.ONGOING;
+		this.examResultStatus = examResultStatus;
 		this.editingType = editingType;
 		this.timeTakeExam = timeTakeExam;
 		this.examRecordSheetFileName = examRecordSheetFileName;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/entity/enums/ExamResultStatus.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/entity/enums/ExamResultStatus.java
@@ -6,7 +6,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum ExamResultStatus {
-	ONGOING("첨삭 진행 중"), FINISH("첨삭 완료");
+	REVIEW_ONGOING("첨삭 진행 중"),
+	REVIEW_FINISH("첨삭 완료"),
+	RE_REVIEW_ONGOING("재첨삭 진행 중"),
+	RE_REVIEW_FINISH("재첨삭 완료");
 
 	private final String status;
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/repository/ExamRecordRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/repository/ExamRecordRepository.java
@@ -2,7 +2,7 @@ package com.nonsoolmate.nonsoolmateServer.domain.examRecord.repository;
 
 import static com.nonsoolmate.nonsoolmateServer.domain.examRecord.exception.ExamRecordExceptionType.*;
 
-import java.util.Optional;
+import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,14 +12,10 @@ import com.nonsoolmate.nonsoolmateServer.domain.university.entity.Exam;
 import com.nonsoolmate.nonsoolmateServer.domain.university.exception.ExamException;
 
 public interface ExamRecordRepository extends JpaRepository<ExamRecord, Long> {
-	Optional<ExamRecord> findByExamAndMember(Exam university, Member member);
+	List<ExamRecord> findByExamAndMember(Exam university, Member member);
 
 	default ExamRecord findByExamAndMemberOrElseThrowException(Exam university, Member member) {
 		return findByExamAndMember(university, member).orElseThrow(
 			() -> new ExamException(NOT_FOUND_UNIVERSITY_EXAM_RECORD));
 	}
-
-	// TODO : 데모데이 이후 삭제 필요.
-	void deleteAllByMember(Member member);
-	// TODO : 데모데이 이후 삭제 필요.
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/repository/ExamRecordRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/repository/ExamRecordRepository.java
@@ -1,7 +1,5 @@
 package com.nonsoolmate.nonsoolmateServer.domain.examRecord.repository;
 
-import static com.nonsoolmate.nonsoolmateServer.domain.examRecord.exception.ExamRecordExceptionType.*;
-
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,13 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.entity.ExamRecord;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
 import com.nonsoolmate.nonsoolmateServer.domain.university.entity.Exam;
-import com.nonsoolmate.nonsoolmateServer.domain.university.exception.ExamException;
 
 public interface ExamRecordRepository extends JpaRepository<ExamRecord, Long> {
 	List<ExamRecord> findByExamAndMember(Exam university, Member member);
-
-	default ExamRecord findByExamAndMemberOrElseThrowException(Exam university, Member member) {
-		return findByExamAndMember(university, member).orElseThrow(
-			() -> new ExamException(NOT_FOUND_UNIVERSITY_EXAM_RECORD));
-	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/repository/ExamRecordRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/repository/ExamRecordRepository.java
@@ -1,13 +1,17 @@
 package com.nonsoolmate.nonsoolmateServer.domain.examRecord.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.entity.ExamRecord;
+import com.nonsoolmate.nonsoolmateServer.domain.examRecord.entity.enums.EditingType;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
 import com.nonsoolmate.nonsoolmateServer.domain.university.entity.Exam;
 
 public interface ExamRecordRepository extends JpaRepository<ExamRecord, Long> {
 	List<ExamRecord> findByExamAndMember(Exam university, Member member);
+
+	Optional<ExamRecord> findByExamAndMemberAndEditingType(Exam exam, Member member, EditingType editingType);
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectCollege/controller/SelectCollegeApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectCollege/controller/SelectCollegeApi.java
@@ -22,7 +22,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
-@Tag(name = "SelectUniversity", description = "목표 단과 대학과 관련된 API")
+@Tag(name = "SelectCollege", description = "목표 단과 대학과 관련된 API")
 public interface SelectCollegeApi {
 
 	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "목표 단과 대학 조회에 성공하였습니다."),})
@@ -37,6 +37,6 @@ public interface SelectCollegeApi {
 	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "목표 단과 대학 수정에 성공하였습니다."),
 		@ApiResponse(responseCode = "400", description = "유효한 목표 대학교가 아닙니다", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))})
 	@Operation(summary = "목표 단과 대학 설정: 리스트 선택", description = "내 목표 대학들 리스트를 업데이트(수정) 합니다.")
-	ResponseEntity<SuccessResponse<SelectCollegeUpdateResponseDTO>> patchSelectUniversities(@AuthUser Member member,
+	ResponseEntity<SuccessResponse<SelectCollegeUpdateResponseDTO>> patchSelectColleges(@AuthUser Member member,
 		@RequestBody @Valid List<SelectUniversityRequestDTO> request);
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectCollege/controller/SelectCollegeController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectCollege/controller/SelectCollegeController.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/select-university")
+@RequestMapping("/select-college")
 public class SelectCollegeController implements SelectCollegeApi {
 
 	private final SelectCollegeService selectCollegeService;
@@ -49,7 +49,7 @@ public class SelectCollegeController implements SelectCollegeApi {
 
 	@Override
 	@PatchMapping
-	public ResponseEntity<SuccessResponse<SelectCollegeUpdateResponseDTO>> patchSelectUniversities(
+	public ResponseEntity<SuccessResponse<SelectCollegeUpdateResponseDTO>> patchSelectColleges(
 		@AuthUser Member member,
 		@RequestBody @Valid final List<SelectUniversityRequestDTO> request) {
 

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectCollege/repository/SelectCollegeRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectCollege/repository/SelectCollegeRepository.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
@@ -21,7 +22,7 @@ public interface SelectCollegeRepository extends JpaRepository<SelectCollege, Lo
 	void deleteAllByMemberId(String memberId);
 
 	@Query("select sc from SelectCollege sc where sc.member =:member order by sc.college.university.universityName asc, sc.college.collegeName asc")
-	List<SelectCollege> findAllByMemberOrderByUniversityNameAscCollegeNameAsc(Member member);
+	List<SelectCollege> findAllByMemberOrderByUniversityNameAscCollegeNameAsc(@Param("member") Member member);
 
 	Optional<SelectCollege> findByMemberAndCollege(Member member, University university);
 

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectCollege/service/SelectCollegeService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectCollege/service/SelectCollegeService.java
@@ -21,7 +21,6 @@ import com.nonsoolmate.nonsoolmateServer.domain.university.entity.College;
 import com.nonsoolmate.nonsoolmateServer.domain.university.entity.Exam;
 import com.nonsoolmate.nonsoolmateServer.domain.university.repository.CollegeRepository;
 import com.nonsoolmate.nonsoolmateServer.domain.university.repository.ExamRepository;
-import com.nonsoolmate.nonsoolmateServer.domain.university.repository.UniversityRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,7 +29,6 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class SelectCollegeService {
 	private static final String BEFORE_EXAM = "시험 응시 전";
-	private final UniversityRepository universityRepository;
 	private final ExamRepository examRepository;
 	private final ExamRecordRepository examRecordRepository;
 	private final SelectCollegeRepository selectCollegeRepository;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectCollege/service/SelectCollegeService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectCollege/service/SelectCollegeService.java
@@ -75,17 +75,31 @@ public class SelectCollegeService {
 
 	private List<SelectCollegeExamResponseDTO> getSelectCollegeExamResponseDTOS(
 		final List<Exam> exams, final Member member) {
-		ExamRecord examRecord;
 		List<SelectCollegeExamResponseDTO> selectCollegeExamResponseDTOS = new ArrayList<>();
 		for (Exam exam : exams) {
-			examRecord = examRecordRepository.findByExamAndMember(exam, member)
-				.orElse(null);
-			String status =
-				examRecord == null ? BEFORE_EXAM : examRecord.getExamResultStatus().getStatus();
-			selectCollegeExamResponseDTOS.add(
-				SelectCollegeExamResponseDTO.of(exam.getExamId(),
-					exam.getExamListName(), exam.getExamTimeLimit(),
-					status));
+			List<ExamRecord> examRecords = examRecordRepository.findByExamAndMember(exam, member);
+			ExamRecord selectedExamRecord = null;
+
+			for (ExamRecord examRecord : examRecords) {
+				if (examRecord.getExamResultStatus().getStatus().equals("REVISION")) {
+					selectedExamRecord = examRecord;
+					break;
+				} else if (examRecord.getExamResultStatus().getStatus().equals("EDITING")) {
+					selectedExamRecord = examRecord;
+				}
+			}
+
+			String status = selectedExamRecord == null
+				? BEFORE_EXAM
+				: selectedExamRecord.getExamResultStatus().getStatus();
+
+			selectCollegeExamResponseDTOS.add(SelectCollegeExamResponseDTO.of(
+					exam.getExamId(),
+					exam.getExamListName(),
+					exam.getExamTimeLimit(),
+					status
+				)
+			);
 		}
 		return selectCollegeExamResponseDTOS;
 	}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectCollege/service/SelectCollegeService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectCollege/service/SelectCollegeService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.entity.ExamRecord;
+import com.nonsoolmate.nonsoolmateServer.domain.examRecord.entity.enums.EditingType;
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.repository.ExamRecordRepository;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
 import com.nonsoolmate.nonsoolmateServer.domain.selectCollege.controller.dto.response.SelectCollegeExamResponseDTO;
@@ -77,17 +78,10 @@ public class SelectCollegeService {
 		final List<Exam> exams, final Member member) {
 		List<SelectCollegeExamResponseDTO> selectCollegeExamResponseDTOS = new ArrayList<>();
 		for (Exam exam : exams) {
-			List<ExamRecord> examRecords = examRecordRepository.findByExamAndMember(exam, member);
-			ExamRecord recentExamRecord = null;
-
-			for (ExamRecord examRecord : examRecords) {
-				if (examRecord.getExamResultStatus().getStatus().equals("REVISION")) {
-					recentExamRecord = examRecord;
-					break;
-				} else if (examRecord.getExamResultStatus().getStatus().equals("EDITING")) {
-					recentExamRecord = examRecord;
-				}
-			}
+			ExamRecord recentExamRecord = examRecordRepository.findByExamAndMemberAndEditingType(exam, member,
+					EditingType.REVISION)
+				.orElse(examRecordRepository.findByExamAndMemberAndEditingType(exam, member, EditingType.EDITING)
+					.orElse(null));
 
 			String status = recentExamRecord == null
 				? BEFORE_EXAM

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectCollege/service/SelectCollegeService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/selectCollege/service/SelectCollegeService.java
@@ -78,20 +78,20 @@ public class SelectCollegeService {
 		List<SelectCollegeExamResponseDTO> selectCollegeExamResponseDTOS = new ArrayList<>();
 		for (Exam exam : exams) {
 			List<ExamRecord> examRecords = examRecordRepository.findByExamAndMember(exam, member);
-			ExamRecord selectedExamRecord = null;
+			ExamRecord recentExamRecord = null;
 
 			for (ExamRecord examRecord : examRecords) {
 				if (examRecord.getExamResultStatus().getStatus().equals("REVISION")) {
-					selectedExamRecord = examRecord;
+					recentExamRecord = examRecord;
 					break;
 				} else if (examRecord.getExamResultStatus().getStatus().equals("EDITING")) {
-					selectedExamRecord = examRecord;
+					recentExamRecord = examRecord;
 				}
 			}
 
-			String status = selectedExamRecord == null
+			String status = recentExamRecord == null
 				? BEFORE_EXAM
-				: selectedExamRecord.getExamResultStatus().getStatus();
+				: recentExamRecord.getExamResultStatus().getStatus();
 
 			selectCollegeExamResponseDTOS.add(SelectCollegeExamResponseDTO.of(
 					exam.getExamId(),

--- a/nonsoolmateServer/src/main/resources/application-local.yml
+++ b/nonsoolmateServer/src/main/resources/application-local.yml
@@ -38,7 +38,7 @@ spring:
         format_sql: true
         show_sql: true
     open-in-view: false
-  #    defer-datasource-initialization: true
+    defer-datasource-initialization: true
   data:
     redis:
       host: localhost


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#92 -> dev


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 시험지 상태에 재첨삭 중, 재첨삭 완료를 추가했습니다
- 자세한 내용은 테크 스펙에 명시했습니다
  - https://www.notion.so/nonsoolmatee/API-64d598c4aa374dd39f50afbe26c753f8?pvs=4 

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="1124" alt="스크린샷 2024-08-30 오후 4 01 35" src="https://github.com/user-attachments/assets/2f2ba227-284b-4b0a-849b-67b50e54f53c">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 클라를 위해 바로 머지하겠습니다! 리뷰 남겨주시면 따로 issue 파서 반영하겠습니다