### PR TITLE
[FEAT] 재첨삭 플로우에 따른 시험지 기록 API 추가 구현

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/ExamRecordApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/ExamRecordApi.java
@@ -23,7 +23,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 
-@Tag(name = "UniversityExamRecord", description = "시험 응시 기록과 관련된 API")
+@Tag(name = "CollegeExamRecord", description = "시험 응시 기록과 관련된 API")
 public interface ExamRecordApi {
 
 	@ApiResponses(
@@ -35,7 +35,7 @@ public interface ExamRecordApi {
 	)
 	@Operation(summary = "첨삭: 첨삭 PDF_해제PDF", description = "첨삭 pdf 및 해제 pdf를 조회합니다.")
 	ResponseEntity<SuccessResponse<ExamRecordResponseDTO>> getExamRecord(
-		@Parameter(description = "해당 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long examId,
+		@Parameter(description = "해당 단과 대학 시험 Id (examId)", required = true) @PathVariable("id") Long examId,
 		@AuthUser Member member);
 
 	@ApiResponses(
@@ -47,7 +47,7 @@ public interface ExamRecordApi {
 	)
 	@Operation(summary = "첨삭: 첨삭 PDF 저장", description = "첨삭 pdf를 조회합니다.")
 	ResponseEntity<SuccessResponse<ExamRecordResultResponseDTO>> getExamRecordResult(
-		@Parameter(description = "해당 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long examId,
+		@Parameter(description = "해당 단과 대학 시험 Id (examId)", required = true) @PathVariable("id") Long examId,
 		@AuthUser Member member);
 
 	@ApiResponses(

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/ExamRecordApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/ExamRecordApi.java
@@ -61,7 +61,7 @@ public interface ExamRecordApi {
 	@ApiResponses(
 		value = {
 			@ApiResponse(responseCode = "201", description = "대학 시험 기록에 성공했습니다."),
-			@ApiResponse(responseCode = "400", description = "존재하지 않는 대학 시험입니다, 이미 응시한 대학 시험입니다", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+			@ApiResponse(responseCode = "400", description = "존재하지 않는 대학 시험입니다, 이미 응시한 대학 시험입니다, 첨삭을 받지 않고 재첨삭을 요청할 수 없습니다", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
 			@ApiResponse(responseCode = "404", description = "해당 답안지 파일 이름을 찾을 수 없습니다", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 		}
 	)

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/ExamRecordController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/ExamRecordController.java
@@ -29,7 +29,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/university/exam-record")
+@RequestMapping("/college/exam-record")
 @RequiredArgsConstructor
 public class ExamRecordController implements ExamRecordApi {
 

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/ExamRecordController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/ExamRecordController.java
@@ -16,6 +16,7 @@ import com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.respon
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.response.ExamRecordResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.response.ExamRecordResultResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.response.ExamSheetPreSignedUrlResponseDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.examRecord.entity.enums.EditingType;
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.exception.ExamRecordSuccessType;
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.service.ExamRecordService;
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.service.ExamRecordSheetService;
@@ -64,13 +65,18 @@ public class ExamRecordController implements ExamRecordApi {
 	@Override
 	@PostMapping("/sheet")
 	public ResponseEntity<SuccessResponse<ExamRecordIdResponse>> createExamRecord(
-		@Valid @RequestBody final CreateExamRecordRequestDTO createExamRecordRequestDTO,
+		@Valid @RequestBody final CreateExamRecordRequestDTO request,
 		@AuthUser final Member member) {
-		ExamRecordIdResponse examRecord = examRecordService.createExamRecord(
-			createExamRecordRequestDTO, member);
+		ExamRecordIdResponse response = null;
+
+		if (request.editingType() == EditingType.REVISION) {
+			response = examRecordService.createRevisionExamRecord(request, member);
+		} else if (request.editingType() == EditingType.EDITING) {
+			response = examRecordService.createEditingExamRecord(request, member);
+		}
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.of(
-			ExamRecordSuccessType.CREATE_EXAM_RECORD_SUCCESS, examRecord
-			));
+			ExamRecordSuccessType.CREATE_EXAM_RECORD_SUCCESS, response
+		));
 	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/dto/request/CreateExamRecordRequestDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/dto/request/CreateExamRecordRequestDTO.java
@@ -1,5 +1,7 @@
 package com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.request;
 
+import com.nonsoolmate.nonsoolmateServer.domain.examRecord.entity.enums.EditingType;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -8,9 +10,10 @@ import jakarta.validation.constraints.Positive;
 public record CreateExamRecordRequestDTO(
 	@NotNull @Schema(description = "대학 시험 id", example = "1") Long examId,
 	@Positive @Schema(description = "사용자가 해당 시험을 보는데 걸린 시간(초 단위)") int memberTakeTimeExam,
-	@NotNull @Schema(description = "PreSingedUrl 발급 시 전달 받은 파일 이름") String memberSheetFileName) {
+	@NotNull @Schema(description = "PreSingedUrl 발급 시 전달 받은 파일 이름") String memberSheetFileName,
+	@NotNull @Schema(description = "첨삭 유형(EDITING, REVISION)", example = "REVIEW") EditingType editingType) {
 	public static CreateExamRecordRequestDTO of(Long examId, int memberTakeTimeExam,
-		String memberSheetFileName) {
-		return new CreateExamRecordRequestDTO(examId, memberTakeTimeExam, memberSheetFileName);
+		String memberSheetFileName, EditingType editingType) {
+		return new CreateExamRecordRequestDTO(examId, memberTakeTimeExam, memberSheetFileName, editingType);
 	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/exception/ExamRecordExceptionType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/exception/ExamRecordExceptionType.java
@@ -13,7 +13,8 @@ public enum ExamRecordExceptionType implements ExceptionType {
 	CREATE_EXAM_RECORD_FAIL(HttpStatus.BAD_REQUEST, "대학 시험 기록 생성에 실패했습니다."),
 	INVALID_EXAM_RECORD_RESULT_FILE_NAME(HttpStatus.BAD_REQUEST, "첨삭이 완료되지 않았습니다."),
 
-	ALREADY_CREATE_EXAM_RECORD(HttpStatus.BAD_REQUEST, "이미 응시한 대학 시험입니다");
+	ALREADY_CREATE_EXAM_RECORD(HttpStatus.BAD_REQUEST, "이미 응시한 대학 시험입니다."),
+	INVALID_CREATE_REVISION_EXAM_RECORD(HttpStatus.BAD_REQUEST, "첨삭을 받지 않고 재첨삭을 요청할 수 없습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/service/ExamRecordService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/service/ExamRecordService.java
@@ -115,8 +115,11 @@ public class ExamRecordService {
 	}
 
 	void validateExistEditingExamRecord(final Exam exam, final Member member) {
-		examRecordRepository.findByExamAndMemberAndEditingType(exam, member,
+		ExamRecord examRecord = examRecordRepository.findByExamAndMemberAndEditingType(exam, member,
 			EditingType.EDITING).orElseThrow(() -> new ExamRecordException(INVALID_CREATE_REVISION_EXAM_RECORD));
+		if (examRecord.getExamResultStatus() == ExamResultStatus.REVIEW_ONGOING) {
+			throw new ExamRecordException(INVALID_CREATE_REVISION_EXAM_RECORD);
+		}
 	}
 
 	private ExamRecord processAndSaveExamRecord(final CreateExamRecordRequestDTO request, final Member member,

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/service/ExamRecordService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/service/ExamRecordService.java
@@ -100,7 +100,7 @@ public class ExamRecordService {
 		validateExam(exam, member, EditingType.REVISION);
 
 		try {
-			final ExamRecord savedExamRecord = processAndSaveExamRecord(request, member, exam, EditingType.EDITING);
+			final ExamRecord savedExamRecord = processAndSaveExamRecord(request, member, exam, EditingType.REVISION);
 			member.decreaseReReviewTicket();
 			return ExamRecordIdResponse.of(savedExamRecord.getExamRecordId());
 		} catch (AWSClientException | MemberException e) {
@@ -125,8 +125,11 @@ public class ExamRecordService {
 	}
 
 	private void validateExam(final Exam exam, final Member member, final EditingType editingType) {
-		examRecordRepository.findByExamAndMemberAndEditingType(exam, member,
-			editingType).orElseThrow(() -> new ExamRecordException(ALREADY_CREATE_EXAM_RECORD));
+		ExamRecord examRecord = examRecordRepository.findByExamAndMemberAndEditingType(exam, member,
+			editingType).orElse(null);
+		if (examRecord != null) {
+			throw new ExamRecordException(ALREADY_CREATE_EXAM_RECORD);
+		}
 	}
 
 	private ExamRecord createExamRecord(final Exam exam, final Member member,

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/service/ExamRecordService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/service/ExamRecordService.java
@@ -15,6 +15,7 @@ import com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.respon
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.response.ExamRecordResultResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.entity.ExamRecord;
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.entity.enums.EditingType;
+import com.nonsoolmate.nonsoolmateServer.domain.examRecord.entity.enums.ExamResultStatus;
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.exception.ExamRecordException;
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.repository.ExamRecordRepository;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
@@ -86,7 +87,9 @@ public class ExamRecordService {
 		} catch (AWSClientException | MemberException e) {
 			throw e;
 		} catch (RuntimeException e) {
-			s3Service.deleteFile(EXAM_SHEET_FOLDER_NAME, request.memberSheetFileName());
+			log.error(e.getMessage());
+			e.printStackTrace();
+			// s3Service.deleteFile(EXAM_SHEET_FOLDER_NAME, request.memberSheetFileName());
 			throw new ExamRecordException(CREATE_EXAM_RECORD_FAIL);
 		}
 	}
@@ -134,11 +137,14 @@ public class ExamRecordService {
 
 	private ExamRecord createExamRecord(final Exam exam, final Member member,
 		final int takeTimeExam, final String sheetFileName, final EditingType editingType) {
+		ExamResultStatus examResultStatus =
+			editingType == EditingType.EDITING ? ExamResultStatus.REVIEW_ONGOING : ExamResultStatus.RE_REVIEW_ONGOING;
 		return ExamRecord.builder()
 			.exam(exam)
 			.member(member)
 			.editingType(editingType)
 			.timeTakeExam(takeTimeExam)
+			.examResultStatus(examResultStatus)
 			.examRecordSheetFileName(sheetFileName)
 			.build();
 	}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/Member.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/entity/Member.java
@@ -86,4 +86,11 @@ public class Member {
 		}
 		this.reviewTicketCount -= 1;
 	}
+
+	public void decreaseReReviewTicket() {
+		if (this.reReviewTicketCount <= 0) {
+			throw new MemberException(MemberExceptionType.MEMBER_USE_TICKET_FAIL);
+		}
+		this.reReviewTicketCount -= 1;
+	}
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#94
- closed #94


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 시험지 기록 요청 시 첨삭에 대한 시험 기록인지, 재첨삭에 대한 시험 기록인지에 따라 로직을 분리했습니다
- 자세한 내용은 테크 스펙 참고 부탁드립니다!
  - https://www.notion.so/nonsoolmatee/API-76b766965a204d02a1e72504a99a5777?pvs=4

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 사용자가 응시한 적 없는 시험(첨삭)에 대해 시험 기록(첨삭)을 생성한 경우
<img width="923" alt="스크린샷 2024-08-30 오후 10 11 30" src="https://github.com/user-attachments/assets/4996b513-095d-4688-b81f-85d833fe951b">
- 사용자가 첨삭이 완료된 시험에 대해 재첨삭 시험 기록을 생성한 경우
<img width="923" alt="스크린샷 2024-08-30 오후 10 12 25" src="https://github.com/user-attachments/assets/9c38e6c6-ddbb-4491-bd2d-8b54f44645c8">
- 사용자가 이미 응시한 시험(첨삭)에 대해 첨삭을 요청하는 경우
<img width="923" alt="스크린샷 2024-08-30 오후 10 11 38" src="https://github.com/user-attachments/assets/e4636e8b-5c5a-4ecd-aced-87c089b6f6e8">
- 사용자가 이미 응시한 시험(재첨삭)에 대해 재첨삭을 요청하는 경우
<img width="923" alt="스크린샷 2024-08-30 오후 10 12 32" src="https://github.com/user-attachments/assets/d2400b81-0c61-41be-84c1-a4a662abeee7">
- 사용자가 첨삭이 완료되지 않은 상태에서 재첨삭을 요청하는 경우
<img width="923" alt="스크린샷 2024-08-30 오후 10 16 09" src="https://github.com/user-attachments/assets/f6ef61cc-cd54-472f-a783-756059c10def">
- 사용자가 첨삭을 받지 않고(첨삭에 대한 시험 기록을 생성하지 않고) 재첨삭을 요청하는 경우
<img width="923" alt="스크린샷 2024-08-30 오후 10 12 55" src="https://github.com/user-attachments/assets/d5bea8b2-4813-4eee-8a21-0bf942b53b2a">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 일단 머지하겠습니다 나중에 리뷰 부탁드립니다!
- 테크 스펙에서 제가 고려하지 못한 예외 케이스가 있다면 조언 부탁드립니다