### PR TITLE
[FEAT] 결제 위젯 호출을 위한 사용자 정보 조회 API 구현

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/service/MemberService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/service/MemberService.java
@@ -7,15 +7,10 @@ import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.N
 import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.ProfileResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.TicketResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
-import com.nonsoolmate.nonsoolmateServer.domain.member.repository.MemberRepository;
-
-import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional(readOnly = true)
-@RequiredArgsConstructor
 public class MemberService {
-	private final MemberRepository memberRepository;
 
 	public NameResponseDTO getNickname(final Member member) {
 		return NameResponseDTO.of(member.getName());
@@ -26,9 +21,7 @@ public class MemberService {
 	}
 
 	public ProfileResponseDTO getProfile(final Member member) {
-		Member foundMember = memberRepository.findByMemberIdOrElseThrow(member.getMemberId());
-
-		return ProfileResponseDTO.of(foundMember.getName(), foundMember.getGender(), foundMember.getBirthYear(),
-			foundMember.getEmail(), foundMember.getPhoneNumber());
+		return ProfileResponseDTO.of(member.getName(), member.getGender(), member.getBirthYear(),
+			member.getEmail(), member.getPhoneNumber());
 	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/service/MemberService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/member/service/MemberService.java
@@ -7,6 +7,7 @@ import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.N
 import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.ProfileResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.member.controller.dto.response.TicketResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
+import com.nonsoolmate.nonsoolmateServer.domain.payment.controller.dto.response.CustomerInfoDTO;
 
 @Service
 @Transactional(readOnly = true)
@@ -23,5 +24,9 @@ public class MemberService {
 	public ProfileResponseDTO getProfile(final Member member) {
 		return ProfileResponseDTO.of(member.getName(), member.getGender(), member.getBirthYear(),
 			member.getEmail(), member.getPhoneNumber());
+	}
+
+	public CustomerInfoDTO getCustomerInfo(final Member member) {
+		return CustomerInfoDTO.of(member.getMemberId(), member.getName(), member.getEmail());
 	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/payment/controller/PaymentApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/payment/controller/PaymentApi.java
@@ -1,0 +1,23 @@
+package com.nonsoolmate.nonsoolmateServer.domain.payment.controller;
+
+import org.springframework.http.ResponseEntity;
+
+import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
+import com.nonsoolmate.nonsoolmateServer.domain.payment.controller.dto.response.CustomerInfoDTO;
+import com.nonsoolmate.nonsoolmateServer.global.security.AuthUser;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "payment", description = "결제와 관련된 API")
+public interface PaymentApi {
+	@ApiResponses(
+		value = {
+			@ApiResponse(responseCode = "200")
+		}
+	)
+	@Operation(summary = "결제 페이지: customer 정보 조회", description = "결제 위젯 호출을 위해 customer의 customerKey, name, email을 조회합니다.")
+	ResponseEntity<CustomerInfoDTO> getCustomerInfo(@AuthUser Member member);
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/payment/controller/PaymentController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/payment/controller/PaymentController.java
@@ -30,7 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequestMapping("/payment")
 @RequiredArgsConstructor
-public class PaymentController {
+public class PaymentController implements PaymentApi {
 	@Value("${payment.toss.widget-secret-key}")
 	private String widgetSecretKey;
 	private final MemberService memberService;

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/payment/controller/PaymentController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/payment/controller/PaymentController.java
@@ -11,20 +11,29 @@ import java.util.Base64;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
+import com.nonsoolmate.nonsoolmateServer.domain.member.service.MemberService;
+import com.nonsoolmate.nonsoolmateServer.domain.payment.controller.dto.response.CustomerInfoDTO;
+import com.nonsoolmate.nonsoolmateServer.global.security.AuthUser;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @Slf4j
+@RequestMapping("/payment")
+@RequiredArgsConstructor
 public class PaymentController {
 	@Value("${payment.toss.widget-secret-key}")
 	private String widgetSecretKey;
+	private final MemberService memberService;
 
 	@RequestMapping(value = "/confirm")
 	public ResponseEntity<JsonNode> confirmPayment(@RequestBody String jsonBody) throws Exception {
@@ -79,5 +88,10 @@ public class PaymentController {
 		}
 
 		return ResponseEntity.status(code).body(jsonObject);
+	}
+
+	@GetMapping("/customer/info")
+	public ResponseEntity<CustomerInfoDTO> getCustomerInfo(@AuthUser Member member) {
+		return ResponseEntity.ok().body(memberService.getCustomerInfo(member));
 	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/payment/controller/dto/response/CustomerInfoDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/payment/controller/dto/response/CustomerInfoDTO.java
@@ -1,0 +1,8 @@
+package com.nonsoolmate.nonsoolmateServer.domain.payment.controller.dto.response;
+
+public record CustomerInfoDTO(String customerKey, String customerName, String customerEmail) {
+	public static CustomerInfoDTO of(final String customerKey, final String customerName,
+		final String customerEmail) {
+		return new CustomerInfoDTO(customerKey, customerName, customerEmail);
+	}
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/payment/controller/dto/response/CustomerInfoDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/payment/controller/dto/response/CustomerInfoDTO.java
@@ -1,6 +1,12 @@
 package com.nonsoolmate.nonsoolmateServer.domain.payment.controller.dto.response;
 
-public record CustomerInfoDTO(String customerKey, String customerName, String customerEmail) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "CustomerInfoDTO", description = "결제 위젯 호출을 위한 고객 정보 응답 DTO")
+public record CustomerInfoDTO(
+	@Schema(description = "위젯 호출 시 필요한 customerKey", example = "edslskdkdksl") String customerKey,
+	@Schema(description = "회원의 이름", example = "김성은") String customerName,
+	@Schema(description = "회원의 email", example = "example@gmail.com") String customerEmail) {
 	public static CustomerInfoDTO of(final String customerKey, final String customerName,
 		final String customerEmail) {
 		return new CustomerInfoDTO(customerKey, customerName, customerEmail);


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#102 -> dev
- closed #102


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 결제 위젯 호출에 필요한 사용자 정보를 조회할 수 있는 API를 개발했습니다
- memberService에서 불필요하게 회원을 한번 더 조회하는 로직에 대하여 이미 filter단에서 조회한 member로부터 getProfile에 필요한 정보를 반환하도록 리팩토링을 진행했습니다(이전에 마이페이지 추가로 오빠가 구현했던 기능인 것 같은데, 코드가 간단하여 해당 PR에서 같이 진행했습니다!)


## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="1411" alt="스크린샷 2024-09-03 오후 7 52 22" src="https://github.com/user-attachments/assets/adc1e4b9-824e-4fbb-8146-1625aa602468">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 지금 MemberService에서 Repository에 접근하는 로직이 전혀 없는데, transactional, service 어노테이션을 붙여두는게 나중을 위해서도 맞을까?라는 생각이 들었습니다!