### PR TITLE
[FEAT] (재)첨삭 결과 조회 API 구현

### DIFF
--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/EditingResultController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/EditingResultController.java
@@ -1,0 +1,29 @@
+package com.nonsoolmate.nonsoolmateServer.domain.examRecord;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.response.EditingResultDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.examRecord.entity.enums.EditingType;
+import com.nonsoolmate.nonsoolmateServer.domain.examRecord.service.ExamRecordService;
+import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
+import com.nonsoolmate.nonsoolmateServer.global.security.AuthUser;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/college/exam")
+@RequiredArgsConstructor
+public class EditingResultController {
+	private final ExamRecordService examRecordService;
+
+	@GetMapping("/{exam-id}/exam-record/result")
+	public ResponseEntity<EditingResultDTO> getExamRecordResult(@PathVariable("exam-id") final long examId,
+		@RequestParam("type") final EditingType type, @AuthUser final Member member) {
+		return ResponseEntity.ok().body(examRecordService.getExamRecordEditingResult(examId, type, member));
+	}
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/EditingResultApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/EditingResultApi.java
@@ -1,0 +1,34 @@
+package com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.response.EditingResultDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.examRecord.entity.enums.EditingType;
+import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
+import com.nonsoolmate.nonsoolmateServer.global.response.ErrorResponse;
+import com.nonsoolmate.nonsoolmateServer.global.security.AuthUser;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "EditingResult", description = "(재)첨삭 결과와 관련된 API")
+public interface EditingResultApi {
+	@ApiResponses(
+		value = {
+			@ApiResponse(responseCode = "200"),
+			@ApiResponse(responseCode = "404", description = "존재하지 않는 시험 응시 기록입니다", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+		}
+	)
+	@Operation(summary = "(재)첨삭 결과 조회 API", description = "(재)첨삭 결과를 조회합니다.")
+	ResponseEntity<EditingResultDTO> getExamRecordResult(
+		@Parameter(description = "해당 단과 대학 시험 Id (examId)", required = true) @PathVariable("exam-id") final long examId,
+		@Parameter(description = "첨삭 유형: 첨삭(EDITING), 재첨삭(REVISION)", required = true) @RequestParam("type") final EditingType type,
+		@AuthUser final Member member);
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/EditingResultController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/EditingResultController.java
@@ -1,4 +1,4 @@
-package com.nonsoolmate.nonsoolmateServer.domain.examRecord;
+package com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/college/exam")
 @RequiredArgsConstructor
-public class EditingResultController {
+public class EditingResultController implements EditingResultApi {
 	private final ExamRecordService examRecordService;
 
 	@GetMapping("/{exam-id}/exam-record/result")

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/dto/response/EditingResultDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/dto/response/EditingResultDTO.java
@@ -2,7 +2,13 @@ package com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.respo
 
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.entity.enums.EditingType;
 
-public record EditingResultDTO(EditingType editingType, String examResultStatus, String examResultFile) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "EditingResultDTO", description = "(재)첨삭 결과 응답 DTO")
+public record EditingResultDTO(
+	@Schema(description = "첨삭 유형(EDITING: 첨삭, REVISION: 재첨삭)", example = "EDITING") EditingType editingType,
+	@Schema(description = "해당 첨삭 진행 상태(첨삭 진행 중, 첨삭 완료, 재첨삭 진행 중, 재첨삭 완료)", example = "첨삭 진행 중") String examResultStatus,
+	@Schema(description = "첨삭 결과 파일 url", example = "https://cloud.nonsoolmate.com/filename") String examResultFile) {
 	public static EditingResultDTO of(EditingType editingType, String examResultStatus, String examResultFile) {
 		return new EditingResultDTO(editingType, examResultStatus, examResultFile);
 	}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/dto/response/EditingResultDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/dto/response/EditingResultDTO.java
@@ -1,0 +1,9 @@
+package com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.response;
+
+import com.nonsoolmate.nonsoolmateServer.domain.examRecord.entity.enums.EditingType;
+
+public record EditingResultDTO(EditingType editingType, String examResultStatus, String examResultFile) {
+	public static EditingResultDTO of(EditingType editingType, String examResultStatus, String examResultFile) {
+		return new EditingResultDTO(editingType, examResultStatus, examResultFile);
+	}
+}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/dto/response/EditingResultDTO.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/controller/dto/response/EditingResultDTO.java
@@ -8,8 +8,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record EditingResultDTO(
 	@Schema(description = "첨삭 유형(EDITING: 첨삭, REVISION: 재첨삭)", example = "EDITING") EditingType editingType,
 	@Schema(description = "해당 첨삭 진행 상태(첨삭 진행 중, 첨삭 완료, 재첨삭 진행 중, 재첨삭 완료)", example = "첨삭 진행 중") String examResultStatus,
-	@Schema(description = "첨삭 결과 파일 url", example = "https://cloud.nonsoolmate.com/filename") String examResultFile) {
-	public static EditingResultDTO of(EditingType editingType, String examResultStatus, String examResultFile) {
-		return new EditingResultDTO(editingType, examResultStatus, examResultFile);
+	@Schema(description = "첨삭 결과 파일 url", example = "https://cloud.nonsoolmate.com/filename") String examResultFileUrl) {
+	public static EditingResultDTO of(EditingType editingType, String examResultStatus, String examResultFileUrl) {
+		return new EditingResultDTO(editingType, examResultStatus, examResultFileUrl);
 	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/exception/ExamRecordExceptionType.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/exception/ExamRecordExceptionType.java
@@ -9,7 +9,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ExamRecordExceptionType implements ExceptionType {
-	NOT_FOUND_UNIVERSITY_EXAM_RECORD(HttpStatus.NOT_FOUND, "존재하지 않는 시험 응시 기록입니다."),
+	NOT_FOUND_EXAM_RECORD(HttpStatus.NOT_FOUND, "존재하지 않는 시험 응시 기록입니다."),
 	CREATE_EXAM_RECORD_FAIL(HttpStatus.BAD_REQUEST, "대학 시험 기록 생성에 실패했습니다."),
 	INVALID_EXAM_RECORD_RESULT_FILE_NAME(HttpStatus.BAD_REQUEST, "첨삭이 완료되지 않았습니다."),
 

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/repository/ExamRecordRepository.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/repository/ExamRecordRepository.java
@@ -1,13 +1,17 @@
 package com.nonsoolmate.nonsoolmateServer.domain.examRecord.repository;
 
+import static com.nonsoolmate.nonsoolmateServer.domain.examRecord.exception.ExamRecordExceptionType.*;
+
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.entity.ExamRecord;
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.entity.enums.EditingType;
+import com.nonsoolmate.nonsoolmateServer.domain.examRecord.exception.ExamRecordException;
 import com.nonsoolmate.nonsoolmateServer.domain.member.entity.Member;
 import com.nonsoolmate.nonsoolmateServer.domain.university.entity.Exam;
 
@@ -22,4 +26,18 @@ public interface ExamRecordRepository extends JpaRepository<ExamRecord, Long> {
 		+ "AND r.member.memberId = :memberId")
 	List<ExamRecord> findAllByExamIdInAndMemberId(List<Long> examIds, String memberId);
 
+	@Query("SELECT r "
+		+ "FROM ExamRecord r "
+		+ "WHERE r.exam.examId = :examId "
+		+ "AND r.member.memberId = :memberId "
+		+ "AND r.editingType = :editingType")
+	Optional<ExamRecord> findByExamAndEditingType(
+		@Param("examId") Long examId,
+		@Param("editingType") EditingType editingType,
+		@Param("memberId") String memberId);
+
+	default ExamRecord findByExamAndMemberAndEditingTypeOrThrow(Long examId, EditingType editingType, String memberId) {
+		return findByExamAndEditingType(examId, editingType, memberId)
+			.orElseThrow(() -> new ExamRecordException(NOT_FOUND_EXAM_RECORD));
+	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/service/ExamRecordService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/service/ExamRecordService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.request.CreateExamRecordRequestDTO;
+import com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.response.EditingResultDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.response.ExamRecordIdResponse;
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.response.ExamRecordResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.examRecord.controller.dto.response.ExamRecordResultResponseDTO;
@@ -161,4 +162,10 @@ public class ExamRecordService {
 		return examRecordRepository.findByExamAndMember(exam, member);
 	}
 
+	public EditingResultDTO getExamRecordEditingResult(final long examId, final EditingType type, final Member member) {
+		ExamRecord examRecord = examRecordRepository.findByExamAndMemberAndEditingTypeOrThrow(examId, type,
+			member.getMemberId());
+		return EditingResultDTO.of(type, examRecord.getExamResultStatus().getStatus(),
+			examRecord.getExamRecordResultFileName());
+	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/service/ExamRecordService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/service/ExamRecordService.java
@@ -163,7 +163,9 @@ public class ExamRecordService {
 	public EditingResultDTO getExamRecordEditingResult(final long examId, final EditingType type, final Member member) {
 		ExamRecord examRecord = examRecordRepository.findByExamAndMemberAndEditingTypeOrThrow(examId, type,
 			member.getMemberId());
-		return EditingResultDTO.of(type, examRecord.getExamResultStatus().getStatus(),
+		String examResultFileUrl = cloudFrontService.createPreSignedGetUrl(EXAM_RESULT_FOLDER_NAME,
 			examRecord.getExamRecordResultFileName());
+		return EditingResultDTO.of(type, examRecord.getExamResultStatus().getStatus(),
+			examResultFileUrl);
 	}
 }

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/service/ExamRecordService.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/examRecord/service/ExamRecordService.java
@@ -88,9 +88,7 @@ public class ExamRecordService {
 		} catch (AWSClientException | MemberException e) {
 			throw e;
 		} catch (RuntimeException e) {
-			log.error(e.getMessage());
-			e.printStackTrace();
-			// s3Service.deleteFile(EXAM_SHEET_FOLDER_NAME, request.memberSheetFileName());
+			s3Service.deleteFile(EXAM_SHEET_FOLDER_NAME, request.memberSheetFileName());
 			throw new ExamRecordException(CREATE_EXAM_RECORD_FAIL);
 		}
 	}

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/ExamApi.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/ExamApi.java
@@ -1,14 +1,9 @@
 package com.nonsoolmate.nonsoolmateServer.domain.university.controller;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.ExamAndAnswerResponseDTO;
-import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.ExamImageAndAnswerResponseDTO;
-import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.ExamImageResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.ExamInfoResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.domain.university.controller.dto.response.ExamUrlResponseDTO;
 import com.nonsoolmate.nonsoolmateServer.global.response.ErrorResponse;
@@ -22,7 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "UniversityExam", description = "대학 시험 정보와 관련된 API")
+@Tag(name = "CollegeExam", description = "단과 대학 시험 정보와 관련된 API")
 public interface ExamApi {
 	@ApiResponses(
 		value = {
@@ -32,7 +27,7 @@ public interface ExamApi {
 	)
 	@Operation(summary = "시험 보기: 시험 이름 & 제한 시간", description = "시험 응시 화면의 이름 및 제한 시간을 조회합니다.")
 	ResponseEntity<SuccessResponse<ExamInfoResponseDTO>> getExamInfo(
-		@Parameter(description = "해당 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long examId);
+		@Parameter(description = "해당 단과 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long examId);
 
 	@ApiResponses(
 		value = {
@@ -42,7 +37,7 @@ public interface ExamApi {
 	)
 	@Operation(summary = "시험 보기: 문제지 [PDF]", description = "시험 응시 화면의 문제지를 조회합니다.")
 	ResponseEntity<SuccessResponse<ExamUrlResponseDTO>> getExamFile(
-		@Parameter(description = "해당 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long id);
+		@Parameter(description = "해당 단과 대학교 시험 Id (examId)", required = true) @PathVariable("id") Long id);
 
 	@ApiResponses(
 		value = {

--- a/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/ExamController.java
+++ b/nonsoolmateServer/src/main/java/com/nonsoolmate/nonsoolmateServer/domain/university/controller/ExamController.java
@@ -18,7 +18,7 @@ import com.nonsoolmate.nonsoolmateServer.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/university/exam")
+@RequestMapping("/college/exam")
 @RequiredArgsConstructor
 public class ExamController implements ExamApi {
 	private final ExamService examService;

--- a/nonsoolmateServer/src/main/resources/application-local.yml
+++ b/nonsoolmateServer/src/main/resources/application-local.yml
@@ -55,7 +55,7 @@ aws-property:
   aws-region: ${DEV_AWS_REGION}
   s3-bucket-name: ${DEV_AWS_BUCKET_NAME}
   distribution-domain: ${DEV_AWS_DISTRIBUTION_DOMAIN}
-  private-key-file-path: ${DEV_AWS_PRIVATE_KEY_FILE_PATH}
+  private-key-file-path: ${LOCAL_AWS_PRIVATE_KEY_FILE_PATH}
   key-pair-id: ${DEV_AWS_KEY_PAIR_ID}
 
 jwt:


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#104 -> dev
- closed #104


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 기존 ExamRecordController에서의 RequestMapping 경로를 university/exam-record에서 college/exam-record로 변경했습니다
- 기존의 첨삭 관련 API 경로(`/university/exam-record/{examId}`)를 다시 생각해보니 exam-record 뒤에 exam-record-id가 아닌 exam-id가 오는 것이 REST API 임을 고려했을 때 부자연스럽다는 생각이 들어 /college/exam/{exam-id}/exam-record ~ 형식으로 path를 지정해보았습니다
  - 관련된 테크 스펙은 다음과 같습니다 -> https://www.notion.so/nonsoolmatee/_-API-d784c32cb7804b47b6db7b92857a975d?pvs=4 

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 첨삭 진행 중
<img width="1411" alt="스크린샷 2024-09-03 오후 9 12 00" src="https://github.com/user-attachments/assets/9fe7522c-fcc7-403b-bdcd-ecf224462cb3">

- 첨삭 완료
<img width="1411" alt="스크린샷 2024-09-03 오후 9 20 32" src="https://github.com/user-attachments/assets/996bd752-3256-46fc-b16c-b28f3bc6c3dd">

- 첨삭을 제출하지 않은 시험지 조회 시
<img width="1411" alt="스크린샷 2024-09-03 오후 9 20 21" src="https://github.com/user-attachments/assets/16976fe0-c744-4526-abba-b1b2ff149f60">

- 재첨삭 진행 중
<img width="1411" alt="스크린샷 2024-09-03 오후 9 21 03" src="https://github.com/user-attachments/assets/53aa5dd8-fa76-4e10-be55-97c8b1577372">

- 재첨삭 완료
<img width="1411" alt="스크린샷 2024-09-03 오후 9 21 11" src="https://github.com/user-attachments/assets/faf47a41-6520-49c9-a966-56a95cf56b82">

- 재첨삭을 제출하지 않은 시험지 조회 시
<img width="1411" alt="image" src="https://github.com/user-attachments/assets/981caae2-374f-48b2-a616-48746b78dc93">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
