### PR TITLE
[FEAT] billing 엔티티에 카드사 정보 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ spotless {
     java {
         target("**/*.java")
         googleJavaFormat("$googleJavaFormatVersion")
-        importOrder('java', 'javax', 'jakarta', 'org', 'com')
+        importOrder('java', 'javax', 'jakarta', 'lombok', 'org', 'com')
         indentWithTabs(2)
         removeUnusedImports()
         trimTrailingWhitespace()

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/auth/controller/AuthController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/auth/controller/AuthController.java
@@ -3,6 +3,9 @@ package com.nonsoolmate.auth.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,9 +26,6 @@ import com.nonsoolmate.exception.common.CommonErrorType;
 import com.nonsoolmate.global.security.service.JwtService;
 import com.nonsoolmate.member.entity.enums.PlatformType;
 import com.nonsoolmate.response.SuccessResponse;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @RequiredArgsConstructor

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/auth/service/AuthService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/auth/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.nonsoolmate.auth.service;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.dao.DataIntegrityViolationException;
 
 import com.nonsoolmate.auth.controller.dto.request.MemberRequestDTO;
@@ -10,8 +12,6 @@ import com.nonsoolmate.member.entity.Member;
 import com.nonsoolmate.member.entity.enums.PlatformType;
 import com.nonsoolmate.member.entity.enums.Role;
 import com.nonsoolmate.member.repository.MemberRepository;
-
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public abstract class AuthService {

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/auth/service/AuthServiceProvider.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/auth/service/AuthServiceProvider.java
@@ -4,11 +4,11 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import jakarta.annotation.PostConstruct;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Component;
 
 import com.nonsoolmate.member.entity.enums.PlatformType;
-
-import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/auth/service/vo/MemberSignUpVO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/auth/service/vo/MemberSignUpVO.java
@@ -1,11 +1,11 @@
 package com.nonsoolmate.auth.service.vo;
 
+import lombok.Builder;
+
 import com.nonsoolmate.auth.controller.enums.AuthType;
 import com.nonsoolmate.member.entity.Member;
 import com.nonsoolmate.member.entity.enums.PlatformType;
 import com.nonsoolmate.member.entity.enums.Role;
-
-import lombok.Builder;
 
 @Builder
 public record MemberSignUpVO(

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/coupon/controller/CouponController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/coupon/controller/CouponController.java
@@ -2,6 +2,8 @@ package com.nonsoolmate.coupon.controller;
 
 import jakarta.validation.Valid;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,8 +17,6 @@ import com.nonsoolmate.coupon.controller.dto.response.GetCouponsResponseDTO;
 import com.nonsoolmate.coupon.service.CouponService;
 import com.nonsoolmate.examRecord.controller.dto.request.RegisterCouponRequestDTO;
 import com.nonsoolmate.global.security.AuthMember;
-
-import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/coupon/controller/dto/request/IssueCouponRequestDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/coupon/controller/dto/request/IssueCouponRequestDTO.java
@@ -4,11 +4,11 @@ import java.time.LocalDateTime;
 
 import jakarta.validation.constraints.NotNull;
 
-import com.nonsoolmate.coupon.entity.Coupon;
-import com.nonsoolmate.coupon.entity.enums.CouponType;
-
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import com.nonsoolmate.coupon.entity.Coupon;
+import com.nonsoolmate.coupon.entity.enums.CouponType;
 
 @RequiredArgsConstructor
 @Getter

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/coupon/controller/dto/response/GetCouponResponseDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/coupon/controller/dto/response/GetCouponResponseDTO.java
@@ -2,12 +2,13 @@ package com.nonsoolmate.coupon.controller.dto.response;
 
 import java.time.LocalDateTime;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 import com.nonsoolmate.coupon.entity.enums.CouponType;
 import com.nonsoolmate.couponMember.repository.dto.CouponResponseDTO;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Schema(name = "GetCouponResponseDTO", description = "쿠폰 조회 DTO")
 @Getter

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/coupon/service/CouponService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/coupon/service/CouponService.java
@@ -5,6 +5,8 @@ import static com.nonsoolmate.exception.coupon.CouponExceptionType.*;
 import java.util.List;
 import java.util.Optional;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,8 +21,6 @@ import com.nonsoolmate.couponMember.repository.CouponMemberRepository;
 import com.nonsoolmate.couponMember.repository.dto.CouponResponseDTO;
 import com.nonsoolmate.examRecord.controller.dto.request.RegisterCouponRequestDTO;
 import com.nonsoolmate.exception.coupon.CouponException;
-
-import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/EditingResultController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/EditingResultController.java
@@ -1,5 +1,7 @@
 package com.nonsoolmate.examRecord.controller;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,8 +13,6 @@ import com.nonsoolmate.examRecord.controller.dto.response.EditingResultDTO;
 import com.nonsoolmate.examRecord.entity.enums.EditingType;
 import com.nonsoolmate.examRecord.service.ExamRecordService;
 import com.nonsoolmate.global.security.AuthMember;
-
-import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/college/exam")

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/ExamRecordController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/ExamRecordController.java
@@ -4,6 +4,8 @@ import static com.nonsoolmate.exception.examRecord.ExamRecordSuccessType.*;
 
 import jakarta.validation.Valid;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,8 +27,6 @@ import com.nonsoolmate.examRecord.service.ExamRecordSheetService;
 import com.nonsoolmate.exception.examRecord.ExamRecordSuccessType;
 import com.nonsoolmate.global.security.AuthMember;
 import com.nonsoolmate.response.SuccessResponse;
-
-import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/college/exam-record")

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/service/ExamRecordService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/service/ExamRecordService.java
@@ -6,6 +6,9 @@ import static com.nonsoolmate.exception.university.ExamExceptionType.*;
 
 import java.util.List;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,9 +31,6 @@ import com.nonsoolmate.member.entity.Member;
 import com.nonsoolmate.member.repository.MemberRepository;
 import com.nonsoolmate.university.entity.Exam;
 import com.nonsoolmate.university.repository.ExamRepository;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Service
 @Transactional(readOnly = true)

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/service/ExamRecordSheetService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/service/ExamRecordSheetService.java
@@ -2,13 +2,13 @@ package com.nonsoolmate.examRecord.service;
 
 import static com.nonsoolmate.aws.FolderName.*;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nonsoolmate.aws.service.CloudFrontService;
 import com.nonsoolmate.aws.service.vo.PreSignedUrlVO;
-
-import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional(readOnly = true)

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/global/aop/ExecutionLoggingAop.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/global/aop/ExecutionLoggingAop.java
@@ -4,6 +4,8 @@ import java.util.Objects;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import lombok.extern.log4j.Log4j2;
+
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -14,8 +16,6 @@ import org.springframework.util.StopWatch;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
-
-import lombok.extern.log4j.Log4j2;
 
 @Aspect
 @Component

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/global/config/SecurityConfig.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.nonsoolmate.global.config;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -18,7 +20,6 @@ import com.nonsoolmate.global.filter.jwt.JwtAuthenticationFilter;
 import com.nonsoolmate.global.filter.jwt.JwtExceptionFilter;
 
 import io.swagger.v3.oas.models.PathItem.HttpMethod;
-import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/global/config/WebConfig.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/global/config/WebConfig.java
@@ -2,13 +2,13 @@ package com.nonsoolmate.global.config;
 
 import java.util.List;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.nonsoolmate.global.security.AuthMemberArgumentResolver;
-
-import lombok.RequiredArgsConstructor;
 
 @Configuration
 @RequiredArgsConstructor

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/global/filter/jwt/JwtAuthenticationFilter.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/global/filter/jwt/JwtAuthenticationFilter.java
@@ -11,6 +11,9 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -24,8 +27,6 @@ import com.nonsoolmate.global.security.utils.RequestUtils;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.security.SignatureException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/global/filter/jwt/JwtExceptionFilter.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/global/filter/jwt/JwtExceptionFilter.java
@@ -7,6 +7,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -15,8 +17,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nonsoolmate.exception.auth.AuthException;
 import com.nonsoolmate.response.ErrorResponse;
-
-import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/global/handler/GlobalExceptionHandler.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/global/handler/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package com.nonsoolmate.global.handler;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -18,8 +20,6 @@ import com.nonsoolmate.exception.common.BusinessException;
 import com.nonsoolmate.exception.common.ClientException;
 import com.nonsoolmate.exception.common.CommonErrorType;
 import com.nonsoolmate.response.ErrorResponse;
-
-import lombok.extern.slf4j.Slf4j;
 
 @RestControllerAdvice
 @Slf4j

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/global/security/service/JwtService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/global/security/service/JwtService.java
@@ -7,6 +7,10 @@ import java.util.Optional;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,9 +30,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.security.SignatureException;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/global/security/service/JwtTokenProvider.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/global/security/service/JwtTokenProvider.java
@@ -3,6 +3,8 @@ package com.nonsoolmate.global.security.service;
 import java.security.Key;
 import java.util.Date;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -14,7 +16,6 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MyController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MyController.java
@@ -2,6 +2,8 @@ package com.nonsoolmate.member.controller;
 
 import static com.nonsoolmate.exception.member.MemberSuccessType.*;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,8 +16,6 @@ import com.nonsoolmate.member.controller.dto.response.ProfileResponseDTO;
 import com.nonsoolmate.member.controller.dto.response.TicketResponseDTO;
 import com.nonsoolmate.member.service.MemberService;
 import com.nonsoolmate.response.SuccessResponse;
-
-import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/my")

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/service/MemberService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/service/MemberService.java
@@ -1,5 +1,7 @@
 package com.nonsoolmate.member.service;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,8 +11,6 @@ import com.nonsoolmate.member.controller.dto.response.TicketResponseDTO;
 import com.nonsoolmate.member.entity.Member;
 import com.nonsoolmate.member.repository.MemberRepository;
 import com.nonsoolmate.payment.controller.dto.response.CustomerInfoDTO;
-
-import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/PaymentController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/PaymentController.java
@@ -9,6 +9,9 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,9 +24,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nonsoolmate.global.security.AuthMember;
 import com.nonsoolmate.member.service.MemberService;
 import com.nonsoolmate.payment.controller.dto.response.CustomerInfoDTO;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @RestController
 @Slf4j

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/selectCollege/controller/SelectCollegeController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/selectCollege/controller/SelectCollegeController.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import jakarta.validation.Valid;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -20,8 +22,6 @@ import com.nonsoolmate.selectCollege.controller.dto.response.SelectCollegeExamsR
 import com.nonsoolmate.selectCollege.controller.dto.response.SelectCollegeResponseDTO;
 import com.nonsoolmate.selectCollege.controller.dto.response.SelectCollegeUpdateResponseDTO;
 import com.nonsoolmate.selectCollege.service.SelectCollegeService;
-
-import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/selectCollege/service/SelectCollegeService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/selectCollege/service/SelectCollegeService.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,8 +24,6 @@ import com.nonsoolmate.university.entity.College;
 import com.nonsoolmate.university.entity.Exam;
 import com.nonsoolmate.university.repository.CollegeRepository;
 import com.nonsoolmate.university.repository.ExamRepository;
-
-import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/university/controller/ExamController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/university/controller/ExamController.java
@@ -2,6 +2,8 @@ package com.nonsoolmate.university.controller;
 
 import static com.nonsoolmate.exception.university.ExamSuccessType.*;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,8 +16,6 @@ import com.nonsoolmate.university.controller.dto.response.ExamAndAnswerResponseD
 import com.nonsoolmate.university.controller.dto.response.ExamInfoResponseDTO;
 import com.nonsoolmate.university.controller.dto.response.ExamUrlResponseDTO;
 import com.nonsoolmate.university.service.ExamService;
-
-import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/college/exam")

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/university/service/ExamService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/university/service/ExamService.java
@@ -3,6 +3,8 @@ package com.nonsoolmate.university.service;
 import static com.nonsoolmate.aws.FolderName.*;
 import static com.nonsoolmate.exception.university.ExamExceptionType.*;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,8 +15,6 @@ import com.nonsoolmate.university.controller.dto.response.ExamInfoResponseDTO;
 import com.nonsoolmate.university.controller.dto.response.ExamUrlResponseDTO;
 import com.nonsoolmate.university.entity.Exam;
 import com.nonsoolmate.university.repository.ExamRepository;
-
-import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional(readOnly = true)

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/auth/AuthExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/auth/AuthExceptionType.java
@@ -1,11 +1,11 @@
 package com.nonsoolmate.exception.auth;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 import com.nonsoolmate.exception.common.ExceptionType;
-
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum AuthExceptionType implements ExceptionType {

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/auth/AuthSuccessType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/auth/AuthSuccessType.java
@@ -1,10 +1,10 @@
 package com.nonsoolmate.exception.auth;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 import com.nonsoolmate.exception.common.SuccessType;
-
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum AuthSuccessType implements SuccessType {

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/aws/AWSExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/aws/AWSExceptionType.java
@@ -1,11 +1,11 @@
 package com.nonsoolmate.exception.aws;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 import com.nonsoolmate.exception.common.ExceptionType;
-
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum AWSExceptionType implements ExceptionType {

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/common/CommonErrorType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/common/CommonErrorType.java
@@ -1,10 +1,10 @@
 package com.nonsoolmate.exception.common;
 
-import org.springframework.http.HttpStatus;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/coupon/CouponExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/coupon/CouponExceptionType.java
@@ -1,11 +1,11 @@
 package com.nonsoolmate.exception.coupon;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 import com.nonsoolmate.exception.common.ExceptionType;
-
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum CouponExceptionType implements ExceptionType {

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/discord/ErrorLogAppenderExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/discord/ErrorLogAppenderExceptionType.java
@@ -1,11 +1,11 @@
 package com.nonsoolmate.exception.discord;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 import com.nonsoolmate.exception.common.ExceptionType;
-
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ErrorLogAppenderExceptionType implements ExceptionType {

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/examRecord/ExamRecordExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/examRecord/ExamRecordExceptionType.java
@@ -1,11 +1,11 @@
 package com.nonsoolmate.exception.examRecord;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 import com.nonsoolmate.exception.common.ExceptionType;
-
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ExamRecordExceptionType implements ExceptionType {

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/examRecord/ExamRecordSuccessType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/examRecord/ExamRecordSuccessType.java
@@ -1,11 +1,11 @@
 package com.nonsoolmate.exception.examRecord;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 import com.nonsoolmate.exception.common.SuccessType;
-
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ExamRecordSuccessType implements SuccessType {

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/member/MemberExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/member/MemberExceptionType.java
@@ -1,11 +1,11 @@
 package com.nonsoolmate.exception.member;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 import com.nonsoolmate.exception.common.ExceptionType;
-
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum MemberExceptionType implements ExceptionType {

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/member/MemberSuccessType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/member/MemberSuccessType.java
@@ -1,10 +1,10 @@
 package com.nonsoolmate.exception.member;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 import com.nonsoolmate.exception.common.SuccessType;
-
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum MemberSuccessType implements SuccessType {

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/selectCollege/SelectCollegeExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/selectCollege/SelectCollegeExceptionType.java
@@ -1,11 +1,11 @@
 package com.nonsoolmate.exception.selectCollege;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 import com.nonsoolmate.exception.common.ExceptionType;
-
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum SelectCollegeExceptionType implements ExceptionType {

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/selectCollege/SelectCollegeSuccessType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/selectCollege/SelectCollegeSuccessType.java
@@ -1,10 +1,10 @@
 package com.nonsoolmate.exception.selectCollege;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 import com.nonsoolmate.exception.common.SuccessType;
-
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum SelectCollegeSuccessType implements SuccessType {

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/university/ExamExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/university/ExamExceptionType.java
@@ -1,11 +1,11 @@
 package com.nonsoolmate.exception.university;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 import com.nonsoolmate.exception.common.ExceptionType;
-
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ExamExceptionType implements ExceptionType {

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/university/ExamSuccessType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/university/ExamSuccessType.java
@@ -1,11 +1,11 @@
 package com.nonsoolmate.exception.university;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 import com.nonsoolmate.exception.common.SuccessType;
-
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ExamSuccessType implements SuccessType {

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/response/ErrorResponse.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/response/ErrorResponse.java
@@ -1,10 +1,10 @@
 package com.nonsoolmate.response;
 
-import com.nonsoolmate.exception.common.ExceptionType;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import com.nonsoolmate.exception.common.ExceptionType;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/response/SuccessResponse.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/response/SuccessResponse.java
@@ -1,11 +1,11 @@
 package com.nonsoolmate.response;
 
-import com.nonsoolmate.exception.common.SuccessType;
-
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import com.nonsoolmate.exception.common.SuccessType;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/common/BaseTimeEntity.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/common/BaseTimeEntity.java
@@ -5,11 +5,11 @@ import java.time.LocalDateTime;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 
+import lombok.Getter;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import lombok.Getter;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/coupon/entity/Coupon.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/coupon/entity/Coupon.java
@@ -10,13 +10,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 
-import com.nonsoolmate.common.BaseTimeEntity;
-import com.nonsoolmate.coupon.entity.enums.CouponType;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.nonsoolmate.common.BaseTimeEntity;
+import com.nonsoolmate.coupon.entity.enums.CouponType;
 
 /**
  * @note: 쿠폰 종류 : 할인율 쿠폰, 금액 쿠폰, 첨삭권 쿠폰

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/couponMember/entity/CouponMember.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/couponMember/entity/CouponMember.java
@@ -6,12 +6,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
 
-import com.nonsoolmate.common.BaseTimeEntity;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.nonsoolmate.common.BaseTimeEntity;
 
 @Entity
 @Getter

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/couponMember/repository/CouponMemberCustomRepositoryImpl.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/couponMember/repository/CouponMemberCustomRepositoryImpl.java
@@ -5,13 +5,13 @@ import static com.nonsoolmate.couponMember.entity.QCouponMember.*;
 
 import java.util.List;
 
+import lombok.RequiredArgsConstructor;
+
 import org.springframework.stereotype.Repository;
 
 import com.nonsoolmate.couponMember.repository.dto.CouponResponseDTO;
 import com.nonsoolmate.couponMember.repository.dto.QCouponResponseDTO;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-
-import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/couponMember/repository/dto/CouponResponseDTO.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/couponMember/repository/dto/CouponResponseDTO.java
@@ -2,10 +2,10 @@ package com.nonsoolmate.couponMember.repository.dto;
 
 import java.time.LocalDateTime;
 
+import lombok.Getter;
+
 import com.nonsoolmate.coupon.entity.enums.CouponType;
 import com.querydsl.core.annotations.QueryProjection;
-
-import lombok.Getter;
 
 @Getter
 public class CouponResponseDTO {

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/examRecord/entity/ExamRecord.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/examRecord/entity/ExamRecord.java
@@ -13,15 +13,15 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 
-import com.nonsoolmate.examRecord.entity.enums.EditingType;
-import com.nonsoolmate.examRecord.entity.enums.ExamResultStatus;
-import com.nonsoolmate.member.entity.Member;
-import com.nonsoolmate.university.entity.Exam;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.nonsoolmate.examRecord.entity.enums.EditingType;
+import com.nonsoolmate.examRecord.entity.enums.ExamResultStatus;
+import com.nonsoolmate.member.entity.Member;
+import com.nonsoolmate.university.entity.Exam;
 
 @Entity
 @Getter

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Member.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Member.java
@@ -8,6 +8,11 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import org.hibernate.validator.constraints.Length;
 
 import com.nonsoolmate.exception.member.MemberException;
@@ -16,10 +21,6 @@ import com.nonsoolmate.member.entity.enums.PlatformType;
 import com.nonsoolmate.member.entity.enums.Role;
 
 import io.hypersistence.utils.hibernate.id.Tsid;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Entity
 @Table(

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Membership.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Membership.java
@@ -10,13 +10,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 
-import com.nonsoolmate.common.BaseTimeEntity;
-import com.nonsoolmate.member.entity.enums.MembershipStatus;
-import com.nonsoolmate.member.entity.enums.MembershipType;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.nonsoolmate.common.BaseTimeEntity;
+import com.nonsoolmate.member.entity.enums.MembershipStatus;
+import com.nonsoolmate.member.entity.enums.MembershipType;
 
 @Entity
 @Getter

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/entity/OrderDetail.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/entity/OrderDetail.java
@@ -7,12 +7,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 
-import com.nonsoolmate.member.entity.Member;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.nonsoolmate.member.entity.Member;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/Billing.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/Billing.java
@@ -8,12 +8,12 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 
-import com.nonsoolmate.member.entity.Member;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.nonsoolmate.member.entity.Member;
 
 @Entity
 @Table(

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/Billing.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/Billing.java
@@ -39,10 +39,15 @@ public class Billing {
 	private String lastTransactionKey;
 
 	@Builder
-	public Billing(final String billingKey, final Member customer, final String cardNumber) {
+	private Billing(
+			final String billingKey,
+			final Member customer,
+			final String cardNumber,
+			final String cardCompany) {
 		this.billingKey = billingKey;
 		this.customer = customer;
 		this.cardNumber = cardNumber;
+		this.cardCompany = cardCompany;
 	}
 
 	public void updateLastTransactionKey(final String lastTransactionKey) {

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/Billing.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/Billing.java
@@ -34,6 +34,8 @@ public class Billing {
 
 	@NotNull private String cardNumber;
 
+	@NotNull private String cardCompany;
+
 	private String lastTransactionKey;
 
 	@Builder

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/TransactionDetail.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/TransactionDetail.java
@@ -11,12 +11,12 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.validation.constraints.NotNull;
 
-import com.nonsoolmate.order.entity.OrderDetail;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.nonsoolmate.order.entity.OrderDetail;
 
 @Entity
 @Table(

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/selectCollege/entity/SelectCollege.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/selectCollege/entity/SelectCollege.java
@@ -8,13 +8,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
-import com.nonsoolmate.member.entity.Member;
-import com.nonsoolmate.university.entity.College;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.nonsoolmate.member.entity.Member;
+import com.nonsoolmate.university.entity.College;
 
 @Entity
 @Getter

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/targetUniversity/entity/TargetUniversity.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/targetUniversity/entity/TargetUniversity.java
@@ -6,12 +6,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 
-import com.nonsoolmate.member.entity.Member;
-import com.nonsoolmate.university.entity.University;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.nonsoolmate.member.entity.Member;
+import com.nonsoolmate.university.entity.University;
 
 @Entity
 @Getter

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/auth/vo/NaverMemberVO.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/auth/vo/NaverMemberVO.java
@@ -1,9 +1,9 @@
 package com.nonsoolmate.auth.vo;
 
+import lombok.Getter;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import lombok.Getter;
 
 @Getter
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/auth/vo/NaverTokenVO.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/auth/vo/NaverTokenVO.java
@@ -1,8 +1,8 @@
 package com.nonsoolmate.auth.vo;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
 import lombok.Getter;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @Getter
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/aws/service/CloudFrontService.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/aws/service/CloudFrontService.java
@@ -8,6 +8,9 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -15,8 +18,6 @@ import com.nonsoolmate.aws.service.vo.PreSignedUrlVO;
 import com.nonsoolmate.exception.aws.AWSBusinessException;
 import com.nonsoolmate.exception.aws.AWSExceptionType;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.cloudfront.CloudFrontUtilities;
 import software.amazon.awssdk.services.cloudfront.model.CannedSignerRequest;
 import software.amazon.awssdk.services.cloudfront.url.SignedUrl;

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/aws/service/S3Service.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/aws/service/S3Service.java
@@ -1,5 +1,8 @@
 package com.nonsoolmate.aws.service;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
@@ -8,8 +11,6 @@ import com.nonsoolmate.exception.aws.AWSBusinessException;
 import com.nonsoolmate.exception.aws.AWSClientException;
 import com.nonsoolmate.exception.aws.AWSExceptionType;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/discord/DiscordAppender.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/discord/DiscordAppender.java
@@ -8,6 +8,9 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
 import com.nonsoolmate.discord.model.EmbedObject;
 import com.nonsoolmate.discord.util.MDCUtil;
 import com.nonsoolmate.discord.util.StringUtil;
@@ -18,8 +21,6 @@ import ch.qos.logback.classic.spi.IThrowableProxy;
 import ch.qos.logback.classic.spi.ThrowableProxyUtil;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import io.micrometer.core.instrument.util.StringEscapeUtils;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Setter

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/discord/filter/MDCFilter.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/discord/filter/MDCFilter.java
@@ -8,15 +8,15 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.WebUtils;
 
 import com.nonsoolmate.discord.util.HttpRequestUtil;
 import com.nonsoolmate.discord.util.MDCUtil;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/discord/filter/ServletWrappingFilter.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/discord/filter/ServletWrappingFilter.java
@@ -7,11 +7,11 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.nonsoolmate.discord.CachedBodyRequestWrapper;
-
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class ServletWrappingFilter extends OncePerRequestFilter {

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/discord/util/ApiCallUtil.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/discord/util/ApiCallUtil.java
@@ -1,13 +1,14 @@
 package com.nonsoolmate.discord.util;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.MediaType;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import com.nonsoolmate.discord.model.JsonObject;
 
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
 @Slf4j

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/discord/util/HttpRequestUtil.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/discord/util/HttpRequestUtil.java
@@ -7,14 +7,14 @@ import java.util.Objects;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.WebUtils;
 
 import com.nonsoolmate.discord.CachedBodyRequestWrapper;
-
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/discord/util/MDCUtil.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/discord/util/MDCUtil.java
@@ -1,13 +1,13 @@
 package com.nonsoolmate.discord.util;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 import org.slf4j.MDC;
 import org.slf4j.spi.MDCAdapter;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MDCUtil {

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/redis/repository/vo/RefreshTokenVO.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/redis/repository/vo/RefreshTokenVO.java
@@ -1,12 +1,12 @@
 package com.nonsoolmate.redis.repository.vo;
 
-import org.springframework.data.annotation.Id;
-import org.springframework.data.redis.core.RedisHash;
-import org.springframework.data.redis.core.index.Indexed;
-
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
 
 @Getter
 @NoArgsConstructor


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#121
- closed #121


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 뷰를 보았을 때 카드사 정보도 필요해서 billing 엔티티에 추가했습니다!
- 다음과 같은 상황에서 토스페이먼츠 측에서 어떤 예외 또는 값을 전달해주시는지에 대해 문의드린 상태라 해당 문의에 대해 답변이 오면 결제 쪽 개발을 시작할 것 같습니다
  - 현재 논술메이트에서 원하는 플로우: A라는 카드를 사용하다가 B라는 카드로 변경을 하게 되면 다음 달 결제부터 B 카드로 적용되길 원함
  - 그러나 이전에 등록한 카드 A를 화면에서 보여주지 않고 변경된 B만 보여주길 원함 또한 기획에 문의했을 때 카드 A에 대한 정보는 따로 저장하지 않아도 된다고 함
  - 사용자가 카드 A를 사용하다가 B로 변경을하고, A로 다시 변경 요청을 보냈을 때 토스페이먼츠에서는 이미 빌링키를 발급한 내역이 있는 카드라고 예외처리를 진행하는지, 아니면 이전에 발급해준 billingKey를 다시 보내주는지가 궁금해 문의를 남긴 상황입니다! 만약 예외처리로 빌링키를 다시 발급되지 않는다면 이 경우에 대한 설계를 다시 고민해봐야할 것 같아서요!

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
