### PR TITLE
[FEAT] 등록된 카드 조회 API 구현

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardApi.java
@@ -1,0 +1,28 @@
+package com.nonsoolmate.payment.controller;
+
+import org.springframework.http.ResponseEntity;
+
+import com.nonsoolmate.global.security.AuthMember;
+import com.nonsoolmate.payment.controller.dto.response.CardResponseDTO;
+import com.nonsoolmate.response.ErrorResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "card", description = "카드등록과 관련된 API")
+public interface CardApi {
+	@ApiResponses(
+			value = {
+				@ApiResponse(responseCode = "200"),
+				@ApiResponse(
+						responseCode = "404",
+						description = "사용자가 카드를 등록하지 않았습니다",
+						content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+			})
+	@Operation(summary = "카드 등록 페이지: 사용자 카드 정보 조회", description = "사용자가 이전에 등록한 카드 정보를 조회합니다")
+	ResponseEntity<CardResponseDTO> getCard(@AuthMember String memberId);
+}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardController.java
@@ -1,0 +1,25 @@
+package com.nonsoolmate.payment.controller;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.nonsoolmate.global.security.AuthMember;
+import com.nonsoolmate.payment.controller.dto.response.CardResponseDTO;
+import com.nonsoolmate.payment.service.BillingService;
+
+@RestController
+@RequestMapping("/cards")
+@RequiredArgsConstructor
+public class CardController implements CardApi {
+	private final BillingService billingService;
+
+	@GetMapping
+	public ResponseEntity<CardResponseDTO> getCard(@AuthMember final String memberId) {
+		CardResponseDTO response = billingService.getCard(memberId);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/dto/response/CardResponseDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/dto/response/CardResponseDTO.java
@@ -1,0 +1,14 @@
+package com.nonsoolmate.payment.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "CardResponseDTO", description = "고객이 등록한 카드에 대한 응답 DTO")
+public record CardResponseDTO(
+		@Schema(description = "사용자가 등록한 카드 id", example = "edslskdkdksl") Long cardId,
+		@Schema(description = "등록된 카드의 회사", example = "한국") String cardCompany,
+		@Schema(description = "등록된 카드의 카드번호", example = "1111-****-1111") String cardNumber) {
+	public static CardResponseDTO of(
+			final Long cardId, final String cardCompany, final String cardNumber) {
+		return new CardResponseDTO(cardId, cardCompany, cardNumber);
+	}
+}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/BillingService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/BillingService.java
@@ -1,0 +1,21 @@
+package com.nonsoolmate.payment.service;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import com.nonsoolmate.payment.controller.dto.response.CardResponseDTO;
+import com.nonsoolmate.payment.entity.Billing;
+import com.nonsoolmate.payment.repository.BillingRepository;
+
+@Service
+@RequiredArgsConstructor
+public class BillingService {
+	private final BillingRepository billingRepository;
+
+	public CardResponseDTO getCard(final String memberId) {
+		Billing billing = billingRepository.findByCustomerIdOrThrow(memberId);
+		return CardResponseDTO.of(
+				billing.getBillingId(), billing.getCardCompany(), billing.getCardNumber());
+	}
+}

--- a/nonsoolmate-api/src/main/resources/application-test.yml
+++ b/nonsoolmate-api/src/main/resources/application-test.yml
@@ -38,7 +38,9 @@ spring:
         format_sql: true
         show_sql: true
     open-in-view: false
-    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: never
   data:
     redis:
       host: localhost

--- a/nonsoolmate-api/src/test/java/com/nonsoolmate/payment/service/BillingServiceTest.java
+++ b/nonsoolmate-api/src/test/java/com/nonsoolmate/payment/service/BillingServiceTest.java
@@ -1,0 +1,78 @@
+package com.nonsoolmate.payment.service;
+
+import static com.nonsoolmate.exception.payment.BillingExceptionType.*;
+import static org.mockito.BDDMockito.*;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.nonsoolmate.exception.payment.BillingException;
+import com.nonsoolmate.member.entity.Member;
+import com.nonsoolmate.member.entity.enums.PlatformType;
+import com.nonsoolmate.member.entity.enums.Role;
+import com.nonsoolmate.payment.controller.dto.response.CardResponseDTO;
+import com.nonsoolmate.payment.entity.Billing;
+import com.nonsoolmate.payment.repository.BillingRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class BillingServiceTest {
+	@Mock BillingRepository billingRepository;
+
+	@InjectMocks BillingService billingService;
+
+	private static final String memberId = "testMemberId";
+
+	@Test
+	@DisplayName("사용자가 등록한 카드를 확인하는 경우")
+	void getCardTestWhenMemberHasRegisteredCard() {
+		// given
+		Member expectedMember =
+				Member.builder()
+						.email("testEmail")
+						.name("testName")
+						.platformType(PlatformType.NAVER)
+						.platformId("testPlatformId")
+						.role(Role.USER)
+						.birthYear("test")
+						.build();
+		Billing expectedBilling =
+				Billing.builder()
+						.billingKey("testBillingKey")
+						.cardCompany("testCardCompany")
+						.cardNumber("testCardNumber")
+						.customer(expectedMember)
+						.build();
+		CardResponseDTO mockResponse =
+				CardResponseDTO.of(
+						expectedBilling.getBillingId(),
+						expectedBilling.getCardCompany(),
+						expectedBilling.getCardNumber());
+
+		given(billingRepository.findByCustomerIdOrThrow(anyString())).willReturn(expectedBilling);
+
+		// when
+		CardResponseDTO response = billingService.getCard(memberId);
+
+		// then
+		Assertions.assertThat(response).isEqualTo(mockResponse);
+	}
+
+	@Test
+	@DisplayName("사용자가 카드를 등록하지 않은 경우")
+	void getCardTestWhenMemberHasNotRegisteredCard() {
+		// given
+		given(billingRepository.findByCustomerIdOrThrow(anyString()))
+				.willThrow(new BillingException(NOT_FOUND_BILLING));
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> billingService.getCard(memberId))
+				.isInstanceOf(BillingException.class)
+				.hasMessage("사용자가 카드를 등록하지 않았습니다");
+	}
+}

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/payment/BillingException.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/payment/BillingException.java
@@ -1,0 +1,10 @@
+package com.nonsoolmate.exception.payment;
+
+import com.nonsoolmate.exception.common.ClientException;
+import com.nonsoolmate.exception.common.ExceptionType;
+
+public class BillingException extends ClientException {
+	public BillingException(ExceptionType exceptionType) {
+		super(exceptionType);
+	}
+}

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/payment/BillingExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/payment/BillingExceptionType.java
@@ -1,0 +1,26 @@
+package com.nonsoolmate.exception.payment;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+
+import com.nonsoolmate.exception.common.ExceptionType;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum BillingExceptionType implements ExceptionType {
+	NOT_FOUND_BILLING(HttpStatus.NOT_FOUND, "사용자가 카드를 등록하지 않았습니다");
+
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public HttpStatus status() {
+		return this.status;
+	}
+
+	@Override
+	public String message() {
+		return this.message;
+	}
+}

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/repository/BillingRepository.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/repository/BillingRepository.java
@@ -1,0 +1,22 @@
+package com.nonsoolmate.payment.repository;
+
+import static com.nonsoolmate.exception.examRecord.ExamRecordExceptionType.*;
+import static com.nonsoolmate.exception.payment.BillingExceptionType.*;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.nonsoolmate.exception.payment.BillingException;
+import com.nonsoolmate.payment.entity.Billing;
+
+public interface BillingRepository extends JpaRepository<Billing, Long> {
+	@Query("SELECT b FROM Billing b WHERE b.customer.memberId = :customerId")
+	Optional<Billing> findByCustomerId(final @Param("customerId") String customerId);
+
+	default Billing findByCustomerIdOrThrow(final String customerId) {
+		return findByCustomerId(customerId).orElseThrow(() -> new BillingException(NOT_FOUND_BILLING));
+	}
+}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#125 -> dev
- closed #125 


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 등록된 카드를 조회하는 API를 구현했습니다
- 테스트도 작성해보았는데 이전에 생성한 repository 코드를 db-core 모듈로 옮기려니 실행이 안되더라고요 TestApplication이 만들어지지 않아서 그런건지 좀 더 파악이 필요할 것 같아서 service test 코드만 간단하게 작성해봤습니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 카드 정보 조회에 성공한 경우
<img width="1411" alt="스크린샷 2024-09-21 오후 10 35 39" src="https://github.com/user-attachments/assets/d95362f2-cc8d-4520-b8e7-2de9647c650b">

- 카드 정보 조회에 실패한 경우
<img width="1411" alt="스크린샷 2024-09-21 오후 10 31 50" src="https://github.com/user-attachments/assets/d407511a-b36f-4cb3-a1ad-7f14d1be8de8">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 카드 등록을 하지 않았을 때에 404 에러를 ClientException으로 처리하는게 맞을지 조금 생각을 해보게 되더라고요
- 사실 리스트 조회에서는 empty가 내려가더라도 200으로 예외를 터트리지 않는데 사용자가 원래 카드 등록을 하지 않은 상태에서 조회를 요청하면 404을 내려주는게 맞을지 갑자기 고민하게 되었습니다..
- 사용자가 요청을 조작해서 발생하는 예외는 또 아닌거 같아서요! 민규님의 의견도 궁금합니다!!