### PR TITLE
[FIX] (재)첨삭이 완료되지 않은 경우 file 경로가 빈 문자열로 내려가도록 수정

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/ExamRecordApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/ExamRecordApi.java
@@ -3,20 +3,16 @@ package com.nonsoolmate.examRecord.controller;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import com.nonsoolmate.examRecord.controller.dto.request.CreateExamRecordRequestDTO;
 import com.nonsoolmate.examRecord.controller.dto.response.ExamRecordIdResponse;
-import com.nonsoolmate.examRecord.controller.dto.response.ExamRecordResponseDTO;
-import com.nonsoolmate.examRecord.controller.dto.response.ExamRecordResultResponseDTO;
 import com.nonsoolmate.examRecord.controller.dto.response.ExamSheetPreSignedUrlResponseDTO;
 import com.nonsoolmate.global.security.AuthMember;
 import com.nonsoolmate.response.ErrorResponse;
 import com.nonsoolmate.response.SuccessResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -25,42 +21,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "CollegeExamRecord", description = "시험 응시 기록과 관련된 API")
 public interface ExamRecordApi {
-
-	@ApiResponses(
-			value = {
-				@ApiResponse(responseCode = "200", description = "첨삭 PDF, 해제 PDF 조회에 성공했습니다."),
-				@ApiResponse(
-						responseCode = "400",
-						description = "존재하지 않는 대학 시험입니다, 첨삭이 완료되지 않았습니다",
-						content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-				@ApiResponse(
-						responseCode = "404",
-						description = "존재하지 않는 시험 응시 기록입니다",
-						content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-			})
-	@Operation(summary = "첨삭: 첨삭 PDF_해제PDF", description = "첨삭 pdf 및 해제 pdf를 조회합니다.")
-	ResponseEntity<SuccessResponse<ExamRecordResponseDTO>> getExamRecord(
-			@Parameter(description = "해당 단과 대학 시험 Id (examId)", required = true) @PathVariable("id")
-					Long examId,
-			@AuthMember String memberId);
-
-	@ApiResponses(
-			value = {
-				@ApiResponse(responseCode = "200", description = "첨삭 PDF 조회에 성공했습니다."),
-				@ApiResponse(
-						responseCode = "400",
-						description = "존재하지 않는 대학 시험입니다, 첨삭이 완료되지 않았습니다",
-						content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-				@ApiResponse(
-						responseCode = "404",
-						description = "존재하지 않는 시험 응시 기록입니다",
-						content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
-			})
-	@Operation(summary = "첨삭: 첨삭 PDF 저장", description = "첨삭 pdf를 조회합니다.")
-	ResponseEntity<SuccessResponse<ExamRecordResultResponseDTO>> getExamRecordResult(
-			@Parameter(description = "해당 단과 대학 시험 Id (examId)", required = true) @PathVariable("id")
-					Long examId,
-			@AuthMember String memberId);
 
 	@ApiResponses(
 			value = {

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/ExamRecordController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/ExamRecordController.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,8 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 import com.nonsoolmate.aws.service.vo.PreSignedUrlVO;
 import com.nonsoolmate.examRecord.controller.dto.request.CreateExamRecordRequestDTO;
 import com.nonsoolmate.examRecord.controller.dto.response.ExamRecordIdResponse;
-import com.nonsoolmate.examRecord.controller.dto.response.ExamRecordResponseDTO;
-import com.nonsoolmate.examRecord.controller.dto.response.ExamRecordResultResponseDTO;
 import com.nonsoolmate.examRecord.controller.dto.response.ExamSheetPreSignedUrlResponseDTO;
 import com.nonsoolmate.examRecord.entity.enums.EditingType;
 import com.nonsoolmate.examRecord.service.ExamRecordService;
@@ -35,27 +32,6 @@ public class ExamRecordController implements ExamRecordApi {
 
 	private final ExamRecordService examRecordService;
 	private final ExamRecordSheetService examRecordSheetService;
-
-	@Override
-	@GetMapping("/{id}")
-	public ResponseEntity<SuccessResponse<ExamRecordResponseDTO>> getExamRecord(
-			@PathVariable("id") Long examId, @AuthMember String memberId) {
-		return ResponseEntity.ok()
-				.body(
-						SuccessResponse.of(
-								GET_EXAM_RECORD_SUCCESS, examRecordService.getExamRecord(examId, memberId)));
-	}
-
-	@Override
-	@GetMapping("/result/{id}")
-	public ResponseEntity<SuccessResponse<ExamRecordResultResponseDTO>> getExamRecordResult(
-			@PathVariable("id") Long examId, @AuthMember String memberId) {
-		return ResponseEntity.ok()
-				.body(
-						SuccessResponse.of(
-								GET_EXAM_RECORD_RESULT_SUCCESS,
-								examRecordService.getExamRecordResult(examId, memberId)));
-	}
 
 	@Override
 	@GetMapping("/sheet/presigned")

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/service/ExamRecordService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/service/ExamRecordService.java
@@ -145,13 +145,20 @@ public class ExamRecordService {
 	}
 
 	public EditingResultDTO getExamRecordEditingResult(
-			final long examId, final EditingType type, final String memberId) {
+			final long examId, final EditingType editingType, final String memberId) {
 		ExamRecord examRecord =
-				examRecordRepository.findByExamAndMemberAndEditingTypeOrThrow(examId, type, memberId);
-		String examResultFileUrl =
-				cloudFrontService.createPreSignedGetUrl(
-						EXAM_RESULT_FOLDER_NAME, examRecord.getExamRecordResultFileName());
+				examRecordRepository.findByExamAndMemberAndEditingTypeOrThrow(
+						examId, editingType, memberId);
+		String examResultFileUrl = getExamResultFileUrl(examRecord.getExamRecordResultFileName());
 		return EditingResultDTO.of(
-				type, examRecord.getExamResultStatus().getStatus(), examResultFileUrl);
+				editingType, examRecord.getExamResultStatus().getStatus(), examResultFileUrl);
+	}
+
+	private String getExamResultFileUrl(final String examRecordResultFileName) {
+		if (examRecordResultFileName == null) {
+			return EXAM_RECORD_RESULT_FILE_NAME_EMPTY;
+		}
+		return cloudFrontService.createPreSignedGetUrl(
+				EXAM_RESULT_FOLDER_NAME, examRecordResultFileName);
 	}
 }

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/examRecord/ExamRecordExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/examRecord/ExamRecordExceptionType.java
@@ -11,7 +11,6 @@ import com.nonsoolmate.exception.common.ExceptionType;
 public enum ExamRecordExceptionType implements ExceptionType {
 	NOT_FOUND_EXAM_RECORD(HttpStatus.NOT_FOUND, "존재하지 않는 시험 응시 기록입니다."),
 	CREATE_EXAM_RECORD_FAIL(HttpStatus.BAD_REQUEST, "대학 시험 기록 생성에 실패했습니다."),
-	INVALID_EXAM_RECORD_RESULT_FILE_NAME(HttpStatus.BAD_REQUEST, "첨삭이 완료되지 않았습니다."),
 
 	ALREADY_CREATE_EXAM_RECORD(HttpStatus.BAD_REQUEST, "이미 응시한 대학 시험입니다."),
 	INVALID_CREATE_REVISION_EXAM_RECORD(HttpStatus.BAD_REQUEST, "첨삭을 받지 않고 재첨삭을 요청할 수 없습니다.");

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/examRecord/repository/ExamRecordRepository.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/examRecord/repository/ExamRecordRepository.java
@@ -16,7 +16,6 @@ import com.nonsoolmate.member.entity.Member;
 import com.nonsoolmate.university.entity.Exam;
 
 public interface ExamRecordRepository extends JpaRepository<ExamRecord, Long> {
-	List<ExamRecord> findByExamAndMember(Exam university, Member member);
 
 	Optional<ExamRecord> findByExamAndMemberAndEditingType(
 			Exam exam, Member member, EditingType editingType);


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- fix/#130 -> dev
- closed #130

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- (재)첨삭이 완료되지 않은 경우에 대해 S3Service를 거치지 않고 file 경로를 바로 "" 빈 문자열로 반환하도록 수정했습니다
- 또한 MVP 개발 시에 사용되었던 첨삭_해제 PDF 조회 API와 첨삭 PDF 다운로드를 위해 만들었던 조회 API를 클라쪽에서 더 이상 사용하지 않는다고 하셔서 삭제했습니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="1411" alt="image" src="https://github.com/user-attachments/assets/a24a9e44-7836-4233-9b74-e59412b49dc4">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
