### PR TITLE
[FEAT] 첨삭 선생님 관련 테이블 추가

### DIFF
--- a/nonsoolmate-api/src/main/resources/discord-appender.xml
+++ b/nonsoolmate-api/src/main/resources/discord-appender.xml
@@ -1,6 +1,6 @@
 <included>
     <appender name="DISCORD"
-               class="com.nonsoolmate.external.discord.DiscordAppender">
+               class="com.nonsoolmate.discord.DiscordAppender">
         <discordWebhookUrl>${DISCORD_WEBHOOK_URI}</discordWebhookUrl>
         <username>Error Log</username>
         <avatarUrl>https://www.greenart.co.kr/upimage/new_editor/20212/20210201112021.jpg</avatarUrl>

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/matching/entity/Matching.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/matching/entity/Matching.java
@@ -1,4 +1,4 @@
-package com.nonsoolmate.teacherMember.entity;
+package com.nonsoolmate.matching.entity;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -13,11 +13,11 @@ import com.nonsoolmate.teacher.entity.Teacher;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class TeacherMember {
+public class Matching {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long teacherMemberId;
+	private Long matchingId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "teacher_id")

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/tag/entity/Tag.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/tag/entity/Tag.java
@@ -1,0 +1,29 @@
+package com.nonsoolmate.tag.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Tag {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long tagId;
+
+    @NotNull
+    private String tagName;
+
+    /**
+     * @implNote :
+     * 모든 테그 데이터가 해당 테이블에서 관리된다.
+     * 특정 도메인의 태그 데이터는 해당 컬럼이 null 이 아닌 row 를 조회한다.
+     * */
+    private Long teacherId;
+}

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/tag/entity/Tag.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/tag/entity/Tag.java
@@ -5,6 +5,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,17 +14,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Tag {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long tagId;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long tagId;
 
-    @NotNull
-    private String tagName;
+	@NotNull private String tagName;
 
-    /**
-     * @implNote :
-     * 모든 테그 데이터가 해당 테이블에서 관리된다.
-     * 특정 도메인의 태그 데이터는 해당 컬럼이 null 이 아닌 row 를 조회한다.
-     * */
-    private Long teacherId;
+	/**
+	 * @implNote : 모든 테그 데이터가 해당 테이블에서 관리된다. 특정 도메인의 태그 데이터는 해당 컬럼이 null 이 아닌 row 를 조회한다.
+	 */
+	private Long teacherId;
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/teacher/entity/Teacher.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/teacher/entity/Teacher.java
@@ -5,6 +5,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.validation.constraints.NotNull;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,18 +15,13 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Teacher {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long teacherId;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long teacherId;
 
-    @NotNull
-    private String teacherName;
+	@NotNull private String teacherName;
 
-    @NotNull
-    private String teacherProfileImageUrl;
+	@NotNull private String teacherProfileImageUrl;
 
-    @NotNull
-    private String introduction;
-
-
+	@NotNull private String introduction;
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/teacher/entity/Teacher.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/teacher/entity/Teacher.java
@@ -1,0 +1,31 @@
+package com.nonsoolmate.teacher.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Teacher {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long teacherId;
+
+    @NotNull
+    private String teacherName;
+
+    @NotNull
+    private String teacherProfileImageUrl;
+
+    @NotNull
+    private String introduction;
+
+
+}

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/teacher/entity/TeacherUniversity.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/teacher/entity/TeacherUniversity.java
@@ -1,28 +1,30 @@
 package com.nonsoolmate.teacher.entity;
 
-import com.nonsoolmate.university.entity.University;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.nonsoolmate.university.entity.University;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class TeacherUniversity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long teacherUniversityId;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long teacherUniversityId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "teacher_id")
-    @NotNull
-    private Teacher teacher;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "teacher_id")
+	@NotNull
+	private Teacher teacher;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "university_id")
-    @NotNull
-    private University university;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "university_id")
+	@NotNull
+	private University university;
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/teacher/entity/TeacherUniversity.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/teacher/entity/TeacherUniversity.java
@@ -1,0 +1,28 @@
+package com.nonsoolmate.teacher.entity;
+
+import com.nonsoolmate.university.entity.University;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TeacherUniversity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long teacherUniversityId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "teacher_id")
+    @NotNull
+    private Teacher teacher;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "university_id")
+    @NotNull
+    private University university;
+}

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/teacherMember/entity/TeacherMember.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/teacherMember/entity/TeacherMember.java
@@ -1,0 +1,30 @@
+package com.nonsoolmate.teacherMember.entity;
+
+
+import com.nonsoolmate.member.entity.Member;
+import com.nonsoolmate.teacher.entity.Teacher;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TeacherMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long teacherMemberId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "teacher_id")
+    @NotNull
+    private Teacher teacher;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    @NotNull
+    private Member member;
+}

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/teacherMember/entity/TeacherMember.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/teacherMember/entity/TeacherMember.java
@@ -1,30 +1,31 @@
 package com.nonsoolmate.teacherMember.entity;
 
-
-import com.nonsoolmate.member.entity.Member;
-import com.nonsoolmate.teacher.entity.Teacher;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import com.nonsoolmate.member.entity.Member;
+import com.nonsoolmate.teacher.entity.Teacher;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class TeacherMember {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long teacherMemberId;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long teacherMemberId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "teacher_id")
-    @NotNull
-    private Teacher teacher;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "teacher_id")
+	@NotNull
+	private Teacher teacher;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    @NotNull
-    private Member member;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id")
+	@NotNull
+	private Member member;
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
feat/#127 -> dev
closed #127 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 첨삭 관련 테이블을 추가했습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- Tag 라는 데이터가 선생님 뿐만 아니라 다른 도메인에서도 충분히 추가될 가능성이 높다고 생각했습니다.
- 그래서 관리하기 편하게 하나의 테이블에서 관리하려고 하는데요!
- 만약 시험관련해서 태그가 추가된다면, Tag 테이블에 exam_id 라는 컬럼을 추가해서 구현할 생각이었습니다!
- TeacherMember 은 선생님과 학생의 N:N 연결테이블입니다!