### PR TITLE
[FEAT] swagger에서 memberId 파라미터에 대해 hidden 속성 true로 지정

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/coupon/controller/CouponApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/coupon/controller/CouponApi.java
@@ -11,6 +11,7 @@ import com.nonsoolmate.examRecord.controller.dto.request.RegisterCouponRequestDT
 import com.nonsoolmate.global.security.AuthMember;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Coupon", description = "쿠폰과 관련된 API")
@@ -22,9 +23,11 @@ public interface CouponApi {
 	ResponseEntity<Void> issueCoupon(@RequestBody @Valid IssueCouponRequestDTO requestDTO);
 
 	@Operation(summary = "쿠폰 목록 조회", description = "사용자가 가지고 있는 쿠폰 목록을 조회합니다.")
-	ResponseEntity<GetCouponsResponseDTO> getCoupons(@AuthMember String memberId);
+	ResponseEntity<GetCouponsResponseDTO> getCoupons(
+			@Parameter(hidden = true) @AuthMember String memberId);
 
 	@Operation(summary = "쿠폰 등록", description = "쿠폰을 등록합니다.")
 	ResponseEntity<Void> registerCoupon(
-			@RequestBody @Valid RegisterCouponRequestDTO requestDTO, @AuthMember String memberId);
+			@RequestBody @Valid RegisterCouponRequestDTO requestDTO,
+			@Parameter(hidden = true) @AuthMember String memberId);
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/EditingResultApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/EditingResultApi.java
@@ -34,5 +34,5 @@ public interface EditingResultApi {
 			@Parameter(description = "첨삭 유형: 첨삭(EDITING), 재첨삭(REVISION)", required = true)
 					@RequestParam("type")
 					final EditingType type,
-			@AuthMember final String memberId);
+			@Parameter(hidden = true) @AuthMember final String memberId);
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/ExamRecordApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/ExamRecordApi.java
@@ -13,6 +13,7 @@ import com.nonsoolmate.response.ErrorResponse;
 import com.nonsoolmate.response.SuccessResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -48,5 +49,5 @@ public interface ExamRecordApi {
 			description = "답안지(시험응시기록) 업로드 후 서버에 기록하기 위해 호출합니다.")
 	ResponseEntity<SuccessResponse<ExamRecordIdResponse>> createExamRecord(
 			@Valid @RequestBody CreateExamRecordRequestDTO createExamRecordRequestDTO,
-			@AuthMember String memberId);
+			@Parameter(hidden = true) @AuthMember String memberId);
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MemberApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MemberApi.java
@@ -22,15 +22,18 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public interface MemberApi {
 	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "이름 조회에 성공하였습니다.")})
 	@Operation(summary = "마이페이지: 이름", description = "내 이름을 조회합니다.")
-	ResponseEntity<SuccessResponse<NameResponseDTO>> getName(@AuthMember String memberId);
+	ResponseEntity<SuccessResponse<NameResponseDTO>> getName(
+			@Parameter(hidden = true) @AuthMember String memberId);
 
 	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "이름 조회에 성공하였습니다.")})
 	@Operation(summary = "내 정보 확인: 첨삭권 개수", description = "내 첨삭권 갯수를 조회합니다.")
-	ResponseEntity<SuccessResponse<TicketResponseDTO>> getTicket(@AuthMember String memberId);
+	ResponseEntity<SuccessResponse<TicketResponseDTO>> getTicket(
+			@Parameter(hidden = true) @AuthMember String memberId);
 
 	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "프로필 조회에 성공하였습니다.")})
 	@Operation(summary = "내 프로필 조회", description = "내 프로필을 조회합니다.")
-	ResponseEntity<SuccessResponse<ProfileResponseDTO>> getProfile(@AuthMember String memberId);
+	ResponseEntity<SuccessResponse<ProfileResponseDTO>> getProfile(
+			@Parameter(hidden = true) @AuthMember String memberId);
 
 	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "프로필 수정에 성공하였습니다.")})
 	@Operation(summary = "내 프로필 수정", description = "내 프로필을 수정합니다.")

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardApi.java
@@ -7,6 +7,7 @@ import com.nonsoolmate.payment.controller.dto.response.CardResponseDTO;
 import com.nonsoolmate.response.ErrorResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -24,5 +25,5 @@ public interface CardApi {
 						content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 			})
 	@Operation(summary = "카드 등록 페이지: 사용자 카드 정보 조회", description = "사용자가 이전에 등록한 카드 정보를 조회합니다")
-	ResponseEntity<CardResponseDTO> getCard(@AuthMember String memberId);
+	ResponseEntity<CardResponseDTO> getCard(@Parameter(hidden = true) @AuthMember String memberId);
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/PaymentApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/PaymentApi.java
@@ -6,6 +6,7 @@ import com.nonsoolmate.global.security.AuthMember;
 import com.nonsoolmate.payment.controller.dto.response.CustomerInfoDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -16,5 +17,6 @@ public interface PaymentApi {
 	@Operation(
 			summary = "결제 페이지: customer 정보 조회",
 			description = "결제 위젯 호출을 위해 customer의 customerKey, name, email을 조회합니다.")
-	ResponseEntity<CustomerInfoDTO> getCustomerInfo(@AuthMember String memberId);
+	ResponseEntity<CustomerInfoDTO> getCustomerInfo(
+			@Parameter(hidden = true) @AuthMember String memberId);
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/selectCollege/controller/SelectCollegeApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/selectCollege/controller/SelectCollegeApi.java
@@ -16,6 +16,7 @@ import com.nonsoolmate.selectCollege.controller.dto.response.SelectCollegeRespon
 import com.nonsoolmate.selectCollege.controller.dto.response.SelectCollegeUpdateResponseDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -31,7 +32,7 @@ public interface SelectCollegeApi {
 			})
 	@Operation(summary = "목표 단과 대학 설정: 리스트 조회", description = "내 목표 단과 대학 리스트를 조회합니다.")
 	ResponseEntity<SuccessResponse<List<SelectCollegeResponseDTO>>> getSelectColleges(
-			@AuthMember String memberId);
+			@Parameter(hidden = true) @AuthMember String memberId);
 
 	@ApiResponses(
 			value = {
@@ -39,7 +40,7 @@ public interface SelectCollegeApi {
 			})
 	@Operation(summary = "마이 페이지: 단과 대학별 시험 리스트 조회", description = "내 목표 단과 대학들의 시험 리스트를 조회합니다.")
 	ResponseEntity<SuccessResponse<List<SelectCollegeExamsResponseDTO>>> getSelectCollegeExams(
-			@AuthMember String memberId);
+			@Parameter(hidden = true) @AuthMember String memberId);
 
 	@ApiResponses(
 			value = {
@@ -51,5 +52,6 @@ public interface SelectCollegeApi {
 			})
 	@Operation(summary = "목표 단과 대학 설정: 리스트 선택", description = "내 목표 대학들 리스트를 업데이트(수정) 합니다.")
 	ResponseEntity<SuccessResponse<SelectCollegeUpdateResponseDTO>> patchSelectColleges(
-			@AuthMember String memberId, @RequestBody @Valid List<SelectUniversityRequestDTO> request);
+			@Parameter(hidden = true) @AuthMember String memberId,
+			@RequestBody @Valid List<SelectUniversityRequestDTO> request);
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#138 -> dev
- closed #138

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- @AuthMember 어노테이션으로 가져오는 memberId에 대해 swagger에서 Parameter(hidden=true)를 사용하여 테스트 시 memberId를 입력하지 않아도 되게 변경했습니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![image](https://github.com/user-attachments/assets/23a25de9-8aeb-44d4-abc4-555d27446fab)


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 방법 알려준 민규오빠 THX~