### PR TITLE
[FEAT] 카드 등록 API 구현

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardApi.java
@@ -1,8 +1,10 @@
 package com.nonsoolmate.payment.controller;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 
 import com.nonsoolmate.global.security.AuthMember;
+import com.nonsoolmate.payment.controller.dto.request.CreateCardRequestDTO;
 import com.nonsoolmate.payment.controller.dto.response.CardResponseDTO;
 import com.nonsoolmate.response.ErrorResponse;
 
@@ -26,4 +28,9 @@ public interface CardApi {
 			})
 	@Operation(summary = "카드 등록 페이지: 사용자 카드 정보 조회", description = "사용자가 이전에 등록한 카드 정보를 조회합니다")
 	ResponseEntity<CardResponseDTO> getCard(@Parameter(hidden = true) @AuthMember String memberId);
+
+	@ApiResponses(value = {@ApiResponse(responseCode = "201")})
+	@Operation(summary = "카드 등록 페이지: 사용자 카드 등록", description = "사용자가 이전에 등록한 카드 정보를 조회합니다")
+	ResponseEntity<CardResponseDTO> registerCard(
+			@RequestBody CreateCardRequestDTO createCardRequestDTO);
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardApi.java
@@ -29,7 +29,14 @@ public interface CardApi {
 	@Operation(summary = "카드 등록 페이지: 사용자 카드 정보 조회", description = "사용자가 이전에 등록한 카드 정보를 조회합니다")
 	ResponseEntity<CardResponseDTO> getCard(@Parameter(hidden = true) @AuthMember String memberId);
 
-	@ApiResponses(value = {@ApiResponse(responseCode = "201")})
+	@ApiResponses(
+			value = {
+				@ApiResponse(responseCode = "201"),
+				@ApiResponse(
+						responseCode = "400",
+						description = "카드 등록에 실패했습니다 (customerKey, authKey가 잘못된 경우)",
+						content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+			})
 	@Operation(summary = "카드 등록 페이지: 사용자 카드 등록", description = "사용자가 이전에 등록한 카드 정보를 조회합니다")
 	ResponseEntity<CardResponseDTO> registerCard(
 			@RequestBody CreateCardRequestDTO createCardRequestDTO);

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardController.java
@@ -1,13 +1,18 @@
 package com.nonsoolmate.payment.controller;
 
+import jakarta.validation.Valid;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nonsoolmate.global.security.AuthMember;
+import com.nonsoolmate.payment.controller.dto.request.CreateCardRequestDTO;
 import com.nonsoolmate.payment.controller.dto.response.CardResponseDTO;
 import com.nonsoolmate.payment.service.BillingService;
 
@@ -20,6 +25,13 @@ public class CardController implements CardApi {
 	@GetMapping
 	public ResponseEntity<CardResponseDTO> getCard(@AuthMember final String memberId) {
 		CardResponseDTO response = billingService.getCard(memberId);
+		return ResponseEntity.ok(response);
+	}
+
+	@PostMapping("/register")
+	public ResponseEntity<CardResponseDTO> registerCard(
+			@RequestBody @Valid CreateCardRequestDTO createCardRequestDTO) {
+		CardResponseDTO response = billingService.registerCard(createCardRequestDTO);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/PaymentController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/PaymentController.java
@@ -1,26 +1,13 @@
 package com.nonsoolmate.payment.controller;
 
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.Reader;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nonsoolmate.global.security.AuthMember;
 import com.nonsoolmate.member.service.MemberService;
 import com.nonsoolmate.payment.controller.dto.response.CustomerInfoDTO;
@@ -30,68 +17,8 @@ import com.nonsoolmate.payment.controller.dto.response.CustomerInfoDTO;
 @RequestMapping("/payment")
 @RequiredArgsConstructor
 public class PaymentController implements PaymentApi {
-	@Value("${payment.toss.widget-secret-key}")
-	private String widgetSecretKey;
 
 	private final MemberService memberService;
-
-	@RequestMapping(value = "/confirm")
-	public ResponseEntity<JsonNode> confirmPayment(@RequestBody String jsonBody) throws Exception {
-
-		ObjectMapper objectMapper = new ObjectMapper();
-		String orderId;
-		String amount;
-		String paymentKey;
-
-		try {
-			// 클라이언트에서 받은 JSON 요청 바디입니다.
-			JsonNode requestData = objectMapper.readTree(jsonBody);
-			paymentKey = requestData.get("paymentKey").asText();
-			orderId = requestData.get("orderId").asText();
-			amount = requestData.get("amount").asText();
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-
-		JsonNode obj =
-				objectMapper
-						.createObjectNode()
-						.put("orderId", orderId)
-						.put("amount", amount)
-						.put("paymentKey", paymentKey);
-
-		// 토스페이먼츠 API는 시크릿 키를 사용자 ID로 사용하고, 비밀번호는 사용하지 않습니다.
-		// 비밀번호가 없다는 것을 알리기 위해 시크릿 키 뒤에 콜론을 추가합니다.
-
-		Base64.Encoder encoder = Base64.getEncoder();
-		byte[] encodedBytes = encoder.encode((widgetSecretKey + ":").getBytes(StandardCharsets.UTF_8));
-		String authorizations = "Basic " + new String(encodedBytes);
-
-		// 결제를 승인하면 결제수단에서 금액이 차감돼요.
-		URL url = new URL("https://api.tosspayments.com/v1/payments/confirm");
-		HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-		connection.setRequestProperty("Authorization", authorizations);
-		connection.setRequestProperty("Content-Type", "application/json");
-		connection.setRequestMethod("POST");
-		connection.setDoOutput(true);
-
-		try (OutputStream outputStream = connection.getOutputStream()) {
-			outputStream.write(obj.toString().getBytes(StandardCharsets.UTF_8));
-		}
-
-		int code = connection.getResponseCode();
-		boolean isSuccess = code == 200;
-
-		InputStream responseStream =
-				isSuccess ? connection.getInputStream() : connection.getErrorStream();
-		JsonNode jsonObject;
-
-		try (Reader reader = new InputStreamReader(responseStream, StandardCharsets.UTF_8)) {
-			jsonObject = objectMapper.readTree(reader);
-		}
-
-		return ResponseEntity.status(code).body(jsonObject);
-	}
 
 	@GetMapping("/customer/info")
 	public ResponseEntity<CustomerInfoDTO> getCustomerInfo(@AuthMember String memberId) {

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/dto/request/CreateCardRequestDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/dto/request/CreateCardRequestDTO.java
@@ -1,0 +1,11 @@
+package com.nonsoolmate.payment.controller.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "CreateCardRequestDTO", description = "카드 등록 요청 DTO")
+public record CreateCardRequestDTO(
+		@Parameter(description = "Toss에서 받은 customerKey", required = true) @NotNull String customerKey,
+		@Parameter(description = "Toss에서 받은 authKey", required = true) @NotNull String authKey) {}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/BillingService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/BillingService.java
@@ -3,18 +3,48 @@ package com.nonsoolmate.payment.service;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.nonsoolmate.member.entity.Member;
+import com.nonsoolmate.member.repository.MemberRepository;
+import com.nonsoolmate.payment.controller.dto.request.CreateCardRequestDTO;
 import com.nonsoolmate.payment.controller.dto.response.CardResponseDTO;
 import com.nonsoolmate.payment.entity.Billing;
 import com.nonsoolmate.payment.repository.BillingRepository;
+import com.nonsoolmate.toss.service.TossPaymentService;
+import com.nonsoolmate.toss.service.vo.TossPaymentBillingVO;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class BillingService {
+	private final MemberRepository memberRepository;
 	private final BillingRepository billingRepository;
+	private final TossPaymentService tossPaymentService;
 
 	public CardResponseDTO getCard(final String memberId) {
 		Billing billing = billingRepository.findByCustomerIdOrThrow(memberId);
+		return CardResponseDTO.of(
+				billing.getBillingId(), billing.getCardCompany(), billing.getCardNumber());
+	}
+
+	@Transactional
+	public CardResponseDTO registerCard(final CreateCardRequestDTO request) {
+
+		TossPaymentBillingVO vo =
+				tossPaymentService.issueBilling(request.customerKey(), request.authKey());
+		Member customer = memberRepository.findByMemberIdOrThrow(request.customerKey());
+
+		Billing billing =
+				Billing.builder()
+						.customer(customer)
+						.billingKey(vo.billingKey())
+						.cardCompany(vo.cardCompany())
+						.cardNumber(vo.cardNumber())
+						.build();
+
+		billingRepository.save(billing);
+
 		return CardResponseDTO.of(
 				billing.getBillingId(), billing.getCardCompany(), billing.getCardNumber());
 	}

--- a/nonsoolmate-api/src/main/resources/application-dev.yml
+++ b/nonsoolmate-api/src/main/resources/application-dev.yml
@@ -69,10 +69,9 @@ management:
     health:
       enabled: true
 
-payment:
-  toss:
-    api-secret-key: ${DEV_PAYMENT_API_KEY}
-    widget-secret-key: ${DEV_PAYMENT_WIDGET_KEY}
+toss:
+  billing:
+    api-key: ${TEST_TOSS_BILLING_API_KEY}
 
 coupon:
   secret: ${COUPON_SECRET}

--- a/nonsoolmate-api/src/main/resources/application-local.yml
+++ b/nonsoolmate-api/src/main/resources/application-local.yml
@@ -74,10 +74,9 @@ management:
     health:
       enabled: true
 
-payment:
-  toss:
-    api-secret-key: ${DEV_PAYMENT_API_KEY}
-    widget-secret-key: ${DEV_PAYMENT_WIDGET_KEY}
+toss:
+  billing:
+    api-key: ${TEST_TOSS_BILLING_API_KEY}
 
 coupon:
   secret: ${COUPON_SECRET}

--- a/nonsoolmate-api/src/main/resources/application-prod.yml
+++ b/nonsoolmate-api/src/main/resources/application-prod.yml
@@ -73,10 +73,9 @@ logging:
   discord:
     webhook-uri: ${PROD_DISCORD_WEB_HOOK_URL}
 
-payment:
-  toss:
-    api-secret-key: ${PROD_PAYMENT_API_KEY}
-    widget-secret-key: ${PROD_PAYMENT_WIDGET_KEY}
+toss:
+  billing:
+    api-key: ${LIVE_TOSS_BILLING_API_KEY}
 
 coupon:
   secret: ${COUPON_SECRET}

--- a/nonsoolmate-api/src/main/resources/application-test.yml
+++ b/nonsoolmate-api/src/main/resources/application-test.yml
@@ -76,10 +76,9 @@ management:
     health:
       enabled: true
 
-payment:
-  toss:
-    api-secret-key: ${DEV_PAYMENT_API_KEY}
-    widget-secret-key: ${DEV_PAYMENT_WIDGET_KEY}
+toss:
+  billing:
+    api-key: ${TEST_TOSS_BILLING_API_KEY}
 
 coupon:
   secret: ${COUPON_SECRET}

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/common/CommonErrorType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/common/CommonErrorType.java
@@ -14,9 +14,12 @@ public enum CommonErrorType implements ExceptionType {
 
 	/** 500 Internal Server Error */
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+	EXTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "외부 서버에서 오류가 발생하였습니다"),
 
 	// 400 Bad Request
 	INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다"),
+	// TODO:: NAVER API 인증 실패에서도 이 에러 타입 사용하기
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "외부 API 인증에 실패하였습니다"),
 	// 415 UNSUPPORTED_MEDIA_TYPE
 	INVALID_JSON_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "올바른 요청 형식이 아닙니다");
 

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/payment/BillingExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/payment/BillingExceptionType.java
@@ -10,8 +10,7 @@ import com.nonsoolmate.exception.common.ExceptionType;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum BillingExceptionType implements ExceptionType {
 	NOT_FOUND_BILLING(HttpStatus.NOT_FOUND, "사용자가 카드를 등록하지 않았습니다"),
-	TOSS_PAYMENT_ISSUE_BILLING(HttpStatus.INTERNAL_SERVER_ERROR, "토스 결제 서버에서 카드 등록에 실패했습니다"),
-	;
+	TOSS_PAYMENT_ISSUE_BILLING(HttpStatus.BAD_REQUEST, "카드 등록에 실패했습니다");
 
 	private final HttpStatus status;
 	private final String message;

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/payment/BillingExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/payment/BillingExceptionType.java
@@ -9,7 +9,9 @@ import com.nonsoolmate.exception.common.ExceptionType;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum BillingExceptionType implements ExceptionType {
-	NOT_FOUND_BILLING(HttpStatus.NOT_FOUND, "사용자가 카드를 등록하지 않았습니다");
+	NOT_FOUND_BILLING(HttpStatus.NOT_FOUND, "사용자가 카드를 등록하지 않았습니다"),
+	TOSS_PAYMENT_ISSUE_BILLING(HttpStatus.INTERNAL_SERVER_ERROR, "토스 결제 서버에서 카드 등록에 실패했습니다"),
+	;
 
 	private final HttpStatus status;
 	private final String message;

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/TossPaymentService.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/TossPaymentService.java
@@ -1,25 +1,40 @@
 package com.nonsoolmate.toss.service;
 
+import static com.nonsoolmate.exception.common.CommonErrorType.*;
 import static com.nonsoolmate.exception.payment.BillingExceptionType.*;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import com.nonsoolmate.exception.common.BusinessException;
+import com.nonsoolmate.exception.payment.BillingException;
 import com.nonsoolmate.toss.service.dto.request.IssueBillingDTO;
 import com.nonsoolmate.toss.service.dto.response.TossPaymentBillingDTO;
 import com.nonsoolmate.toss.service.vo.TossPaymentBillingVO;
 
+import reactor.core.publisher.Mono;
+
 @Service
 public class TossPaymentService {
 	private static final String TOSS_AUTHORIZATION_HEADER = "Authorization";
-	private static final String TOSS_AUTHORIZATION_PREFIX = "Basic";
+	private static final String TOSS_AUTHORIZATION_PREFIX = "Basic ";
 	private static final String TOSS_ISSUE_BILLING_URI =
 			"https://api.tosspayments.com/v1/billing/authorizations/issue";
+	private final String secretKey;
 
-	@Value("${toss.billing.api-key}")
-	private String accessToken;
+	public TossPaymentService(@Value("${toss.billing.api-key}") String apiKey) {
+		this.secretKey = getSecretKey(apiKey);
+	}
+
+	private String getSecretKey(String apiKey) {
+		return Base64.getEncoder().encodeToString(apiKey.getBytes(StandardCharsets.UTF_8));
+	}
 
 	public TossPaymentBillingVO issueBilling(final String customerKey, final String authKey) {
 		WebClient webClient = WebClient.builder().build();
@@ -30,9 +45,9 @@ public class TossPaymentService {
 					webClient
 							.post()
 							.uri(TOSS_ISSUE_BILLING_URI)
-							.header(TOSS_AUTHORIZATION_HEADER, TOSS_AUTHORIZATION_PREFIX + accessToken)
+							.header(TOSS_AUTHORIZATION_HEADER, TOSS_AUTHORIZATION_PREFIX + secretKey)
 							.header("Content-Type", "application/json")
-							.body(issueBillingDTO, IssueBillingDTO.class)
+							.body(Mono.just(issueBillingDTO), IssueBillingDTO.class)
 							.retrieve()
 							.bodyToMono(TossPaymentBillingDTO.class)
 							.block();
@@ -42,8 +57,16 @@ public class TossPaymentService {
 					tossPaymentBillingDTO.billingKey(),
 					tossPaymentBillingDTO.cardCompany(),
 					tossPaymentBillingDTO.cardNumber());
-		} catch (RuntimeException e) {
-			throw new BusinessException(TOSS_PAYMENT_ISSUE_BILLING);
+		} catch (WebClientResponseException e) {
+			boolean isUnauthorized = e.getStatusCode().equals(HttpStatus.UNAUTHORIZED);
+			boolean isNotFound = e.getStatusCode().equals(HttpStatus.NOT_FOUND);
+			if (isUnauthorized) {
+				throw new BusinessException(UNAUTHORIZED);
+			} else if (isNotFound) {
+				throw new BillingException(TOSS_PAYMENT_ISSUE_BILLING);
+			} else {
+				throw new BusinessException(EXTERNAL_SERVER_ERROR);
+			}
 		}
 	}
 }

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/TossPaymentService.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/TossPaymentService.java
@@ -37,26 +37,28 @@ public class TossPaymentService {
 	}
 
 	public TossPaymentBillingVO issueBilling(final String customerKey, final String authKey) {
-		WebClient webClient = WebClient.builder().build();
 		IssueBillingDTO issueBillingDTO = IssueBillingDTO.of(authKey, customerKey);
+		TossPaymentBillingDTO tossPaymentBillingDTO = getTossPaymentBillingDTO(issueBillingDTO);
 
+		return TossPaymentBillingVO.of(
+				tossPaymentBillingDTO.customerKey(),
+				tossPaymentBillingDTO.billingKey(),
+				tossPaymentBillingDTO.cardCompany(),
+				tossPaymentBillingDTO.cardNumber());
+	}
+
+	private TossPaymentBillingDTO getTossPaymentBillingDTO(IssueBillingDTO request) {
+		WebClient webClient = WebClient.builder().build();
 		try {
-			TossPaymentBillingDTO tossPaymentBillingDTO =
-					webClient
-							.post()
-							.uri(TOSS_ISSUE_BILLING_URI)
-							.header(TOSS_AUTHORIZATION_HEADER, TOSS_AUTHORIZATION_PREFIX + secretKey)
-							.header("Content-Type", "application/json")
-							.body(Mono.just(issueBillingDTO), IssueBillingDTO.class)
-							.retrieve()
-							.bodyToMono(TossPaymentBillingDTO.class)
-							.block();
-
-			return TossPaymentBillingVO.of(
-					tossPaymentBillingDTO.customerKey(),
-					tossPaymentBillingDTO.billingKey(),
-					tossPaymentBillingDTO.cardCompany(),
-					tossPaymentBillingDTO.cardNumber());
+			return webClient
+					.post()
+					.uri(TOSS_ISSUE_BILLING_URI)
+					.header(TOSS_AUTHORIZATION_HEADER, TOSS_AUTHORIZATION_PREFIX + secretKey)
+					.header("Content-Type", "application/json")
+					.body(Mono.just(request), IssueBillingDTO.class)
+					.retrieve()
+					.bodyToMono(TossPaymentBillingDTO.class)
+					.block();
 		} catch (WebClientResponseException e) {
 			boolean isUnauthorized = e.getStatusCode().equals(HttpStatus.UNAUTHORIZED);
 			boolean isNotFound = e.getStatusCode().equals(HttpStatus.NOT_FOUND);

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/TossPaymentService.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/TossPaymentService.java
@@ -42,7 +42,7 @@ public class TossPaymentService {
 					tossPaymentBillingDTO.billingKey(),
 					tossPaymentBillingDTO.cardCompany(),
 					tossPaymentBillingDTO.cardNumber());
-		} catch (Exception e) {
+		} catch (RuntimeException e) {
 			throw new BusinessException(TOSS_PAYMENT_ISSUE_BILLING);
 		}
 	}

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/TossPaymentService.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/TossPaymentService.java
@@ -1,0 +1,49 @@
+package com.nonsoolmate.toss.service;
+
+import static com.nonsoolmate.exception.payment.BillingExceptionType.*;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.nonsoolmate.exception.common.BusinessException;
+import com.nonsoolmate.toss.service.dto.request.IssueBillingDTO;
+import com.nonsoolmate.toss.service.dto.response.TossPaymentBillingDTO;
+import com.nonsoolmate.toss.service.vo.TossPaymentBillingVO;
+
+@Service
+public class TossPaymentService {
+	private static final String TOSS_AUTHORIZATION_HEADER = "Authorization";
+	private static final String TOSS_AUTHORIZATION_PREFIX = "Basic";
+	private static final String TOSS_ISSUE_BILLING_URI =
+			"https://api.tosspayments.com/v1/billing/authorizations/issue";
+
+	@Value("${toss.billing.api-key}")
+	private String accessToken;
+
+	public TossPaymentBillingVO issueBilling(final String customerKey, final String authKey) {
+		WebClient webClient = WebClient.builder().build();
+		IssueBillingDTO issueBillingDTO = IssueBillingDTO.of(authKey, customerKey);
+
+		try {
+			TossPaymentBillingDTO tossPaymentBillingDTO =
+					webClient
+							.post()
+							.uri(TOSS_ISSUE_BILLING_URI)
+							.header(TOSS_AUTHORIZATION_HEADER, TOSS_AUTHORIZATION_PREFIX + accessToken)
+							.header("Content-Type", "application/json")
+							.body(issueBillingDTO, IssueBillingDTO.class)
+							.retrieve()
+							.bodyToMono(TossPaymentBillingDTO.class)
+							.block();
+
+			return TossPaymentBillingVO.of(
+					tossPaymentBillingDTO.customerKey(),
+					tossPaymentBillingDTO.billingKey(),
+					tossPaymentBillingDTO.cardCompany(),
+					tossPaymentBillingDTO.cardNumber());
+		} catch (Exception e) {
+			throw new BusinessException(TOSS_PAYMENT_ISSUE_BILLING);
+		}
+	}
+}

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/dto/request/IssueBillingDTO.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/dto/request/IssueBillingDTO.java
@@ -1,0 +1,7 @@
+package com.nonsoolmate.toss.service.dto.request;
+
+public record IssueBillingDTO(String authKey, String customerKey) {
+	public static IssueBillingDTO of(final String authKey, final String customerKey) {
+		return new IssueBillingDTO(authKey, customerKey);
+	}
+}

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/dto/response/TossPaymentBillingDTO.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/dto/response/TossPaymentBillingDTO.java
@@ -1,0 +1,14 @@
+package com.nonsoolmate.toss.service.dto.response;
+
+public record TossPaymentBillingDTO(
+		String mId,
+		String customerKey,
+		String authenticatedAt,
+		String method,
+		String billingKey,
+		CardInfo card,
+		String cardCompany,
+		String cardNumber) {
+	public record CardInfo(
+			String issuerCode, String acquirerCode, String number, String cardType, String ownerType) {}
+}

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/vo/TossPaymentBillingVO.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/vo/TossPaymentBillingVO.java
@@ -1,0 +1,12 @@
+package com.nonsoolmate.toss.service.vo;
+
+public record TossPaymentBillingVO(
+		String customerKey, String billingKey, String cardCompany, String cardNumber) {
+	public static TossPaymentBillingVO of(
+			final String customerKey,
+			final String billingKey,
+			final String cardCompany,
+			final String cardNumber) {
+		return new TossPaymentBillingVO(customerKey, billingKey, cardCompany, cardNumber);
+	}
+}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#129
- closed #129


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 카드 등록 API를 구현했습니다
- 소영 언니에게 부탁해서 테스트까지 완료했습니다!
- 테스트는 내일 구현해서 별도로 PR push 해두겠습니다!!

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 카드 번호는 가렸습니다!
<img width="637" alt="image" src="https://github.com/user-attachments/assets/de40d6cb-0992-4d62-87d5-0e6d587c3963">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
