### PR TITLE
[FIX] 선택 단과 대학 시험지 리스트 조회 null로 넘어가는 문제 수정

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/selectCollege/controller/SelectCollegeApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/selectCollege/controller/SelectCollegeApi.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import com.nonsoolmate.global.security.AuthMember;
 import com.nonsoolmate.response.ErrorResponse;
 import com.nonsoolmate.response.SuccessResponse;
-import com.nonsoolmate.selectCollege.controller.dto.request.SelectUniversityRequestDTO;
+import com.nonsoolmate.selectCollege.controller.dto.request.SelectCollegeRequestDTO;
 import com.nonsoolmate.selectCollege.controller.dto.response.SelectCollegeExamsResponseDTO;
 import com.nonsoolmate.selectCollege.controller.dto.response.SelectCollegeResponseDTO;
 import com.nonsoolmate.selectCollege.controller.dto.response.SelectCollegeUpdateResponseDTO;
@@ -53,5 +53,5 @@ public interface SelectCollegeApi {
 	@Operation(summary = "목표 단과 대학 설정: 리스트 선택", description = "내 목표 대학들 리스트를 업데이트(수정) 합니다.")
 	ResponseEntity<SuccessResponse<SelectCollegeUpdateResponseDTO>> patchSelectColleges(
 			@Parameter(hidden = true) @AuthMember String memberId,
-			@RequestBody @Valid List<SelectUniversityRequestDTO> request);
+			@RequestBody @Valid List<SelectCollegeRequestDTO> request);
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/selectCollege/controller/SelectCollegeController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/selectCollege/controller/SelectCollegeController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.nonsoolmate.global.security.AuthMember;
 import com.nonsoolmate.response.SuccessResponse;
-import com.nonsoolmate.selectCollege.controller.dto.request.SelectUniversityRequestDTO;
+import com.nonsoolmate.selectCollege.controller.dto.request.SelectCollegeRequestDTO;
 import com.nonsoolmate.selectCollege.controller.dto.response.SelectCollegeExamsResponseDTO;
 import com.nonsoolmate.selectCollege.controller.dto.response.SelectCollegeResponseDTO;
 import com.nonsoolmate.selectCollege.controller.dto.response.SelectCollegeUpdateResponseDTO;
@@ -56,10 +56,10 @@ public class SelectCollegeController implements SelectCollegeApi {
 	@PatchMapping
 	public ResponseEntity<SuccessResponse<SelectCollegeUpdateResponseDTO>> patchSelectColleges(
 			@AuthMember String memberId,
-			@RequestBody @Valid final List<SelectUniversityRequestDTO> request) {
+			@RequestBody @Valid final List<SelectCollegeRequestDTO> request) {
 
 		List<Long> selectedCollegeIds =
-				request.stream().map(SelectUniversityRequestDTO::collegeId).toList();
+				request.stream().map(SelectCollegeRequestDTO::collegeId).toList();
 
 		return ResponseEntity.ok()
 				.body(

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/selectCollege/controller/dto/request/SelectCollegeRequestDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/selectCollege/controller/dto/request/SelectCollegeRequestDTO.java
@@ -4,5 +4,5 @@ import jakarta.validation.constraints.NotNull;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-public record SelectUniversityRequestDTO(
+public record SelectCollegeRequestDTO(
 		@NotNull @Schema(description = "사용자가 선택한 단과 대학 id", example = "1") Long collegeId) {}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/selectCollege/service/SelectCollegeService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/selectCollege/service/SelectCollegeService.java
@@ -57,10 +57,9 @@ public class SelectCollegeService {
 	public List<SelectCollegeExamsResponseDTO> getSelectCollegeExams(final String memberId) {
 		final List<SelectCollege> sortedSelectColleges =
 				selectCollegeRepository.findAllByMemberOrderByUniversityNameAscCollegeNameAsc(memberId);
-		final List<Long> sortedSelectCollegeIds = getSortedSelectCollegeIds(sortedSelectColleges);
-
+		final List<Long> sortedCollegeIds = getSortedCollegeIds(sortedSelectColleges);
 		final List<Exam> exams =
-				examRepository.findAllByCollegeIdInOrderByExamYearDesc(sortedSelectCollegeIds);
+				examRepository.findAllByCollegeIdInOrderByExamYearDesc(sortedCollegeIds);
 		final List<Long> examIds = exams.stream().map(Exam::getExamId).toList();
 
 		ExamRecordGroups examRecordGroups =
@@ -72,8 +71,10 @@ public class SelectCollegeService {
 		return getSelectCollegeExamsResponseDTOS(sortedSelectColleges, examResponseMap);
 	}
 
-	private List<Long> getSortedSelectCollegeIds(List<SelectCollege> sortedSelectColleges) {
-		return sortedSelectColleges.stream().map(SelectCollege::getSelectCollegeId).toList();
+	private List<Long> getSortedCollegeIds(List<SelectCollege> sortedSelectColleges) {
+		return sortedSelectColleges.stream()
+				.map(selectCollege -> selectCollege.getCollege().getCollegeId())
+				.toList();
 	}
 
 	/**


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- fix/#148 -> dev
- closed #148


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- SelectCollege를 조회하고 그 안에서 단과 대학의 id를 가져와야하는데 SelectCollege의 pk를 가져오고 있어 null로 반환되는 문제를 확인하여 이를 수정했습니다!

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 이전 응답값 결과
<img width="840" alt="스크린샷 2024-09-29 오후 2 33 33" src="https://github.com/user-attachments/assets/b2530038-840f-4b31-b0db-d69617327552">
- 코드 수정 후 응답값 결과
<img width="844" alt="스크린샷 2024-09-29 오후 2 35 12" src="https://github.com/user-attachments/assets/56dbf797-a1d0-4c45-b940-7e7495eca9a0">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
