### PR TITLE
[FEAT] 카드 변경 API 구현

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardApi.java
@@ -4,7 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
 import com.nonsoolmate.global.security.AuthMember;
-import com.nonsoolmate.payment.controller.dto.request.CreateCardRequestDTO;
+import com.nonsoolmate.payment.controller.dto.request.CreateOrUpdateCardRequestDTO;
 import com.nonsoolmate.payment.controller.dto.response.CardResponseDTO;
 import com.nonsoolmate.response.ErrorResponse;
 
@@ -16,11 +16,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "card", description = "카드등록과 관련된 API")
+@Tag(name = "card", description = "카드 등록과 관련된 API")
 public interface CardApi {
 	@ApiResponses(
 			value = {
-				@ApiResponse(responseCode = "200"),
+				@ApiResponse(responseCode = "200", description = "사용자 카드 정보 조회에 성공했습니다"),
 				@ApiResponse(
 						responseCode = "404",
 						description = "사용자가 카드를 등록하지 않았습니다",
@@ -31,7 +31,7 @@ public interface CardApi {
 
 	@ApiResponses(
 			value = {
-				@ApiResponse(responseCode = "201"),
+				@ApiResponse(responseCode = "201", description = "카드 등록에 성공했습니다"),
 				@ApiResponse(
 						responseCode = "400",
 						description = "카드 등록에 실패했습니다 (customerKey, authKey가 잘못된 경우)",
@@ -39,5 +39,21 @@ public interface CardApi {
 			})
 	@Operation(summary = "카드 등록 페이지: 사용자 카드 등록", description = "사용자가 이전에 등록한 카드 정보를 조회합니다")
 	ResponseEntity<CardResponseDTO> registerCard(
-			@RequestBody CreateCardRequestDTO createCardRequestDTO);
+			@RequestBody CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO);
+
+	@ApiResponses(
+			value = {
+				@ApiResponse(responseCode = "200", description = "카드 변경에 성공했습니다"),
+				@ApiResponse(
+						responseCode = "400",
+						description = "카드 등록에 실패했습니다 (customerKey, authKey가 잘못된 경우)",
+						content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+				@ApiResponse(
+						responseCode = "404",
+						description = "사용자가 카드를 등록하지 않았습니다",
+						content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+			})
+	@Operation(summary = "카드 등록 페이지: 사용자 카드 변경", description = "사용자가 이전에 등록한 카드 정보를 조회합니다")
+	ResponseEntity<CardResponseDTO> updateCard(
+			@RequestBody CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO);
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardController.java
@@ -7,12 +7,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nonsoolmate.global.security.AuthMember;
-import com.nonsoolmate.payment.controller.dto.request.CreateCardRequestDTO;
+import com.nonsoolmate.payment.controller.dto.request.CreateOrUpdateCardRequestDTO;
 import com.nonsoolmate.payment.controller.dto.response.CardResponseDTO;
 import com.nonsoolmate.payment.service.BillingService;
 
@@ -30,8 +31,15 @@ public class CardController implements CardApi {
 
 	@PostMapping("/register")
 	public ResponseEntity<CardResponseDTO> registerCard(
-			@RequestBody @Valid CreateCardRequestDTO createCardRequestDTO) {
-		CardResponseDTO response = billingService.registerCard(createCardRequestDTO);
+			@RequestBody @Valid CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO) {
+		CardResponseDTO response = billingService.registerCard(createOrUpdateCardRequestDTO);
+		return ResponseEntity.ok(response);
+	}
+
+	@PutMapping("/update")
+	public ResponseEntity<CardResponseDTO> updateCard(
+			@RequestBody @Valid CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO) {
+		CardResponseDTO response = billingService.updateCard(createOrUpdateCardRequestDTO);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/dto/request/CreateOrUpdateCardRequestDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/dto/request/CreateOrUpdateCardRequestDTO.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "CreateCardRequestDTO", description = "카드 등록 요청 DTO")
-public record CreateCardRequestDTO(
+@Schema(name = "CreateOrUpdateCardRequestDTO", description = "카드 등록 또는 변경 요청 DTO")
+public record CreateOrUpdateCardRequestDTO(
 		@Parameter(description = "Toss에서 받은 customerKey", required = true) @NotNull String customerKey,
 		@Parameter(description = "Toss에서 받은 authKey", required = true) @NotNull String authKey) {}

--- a/nonsoolmate-api/src/test/java/com/nonsoolmate/payment/service/BillingServiceTest.java
+++ b/nonsoolmate-api/src/test/java/com/nonsoolmate/payment/service/BillingServiceTest.java
@@ -168,6 +168,21 @@ class BillingServiceTest {
 		Assertions.assertThat(response).isEqualTo(expectedResponse);
 	}
 
+	@Test
+	@DisplayName("사용자가 카드 등록을 하지 않고 카드 변경을 요청하는 경우")
+	void updateCardTestWhenMemberHasNotRegisteredCard() {
+		// given
+		CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO =
+				new CreateOrUpdateCardRequestDTO(MEMBER_ID, TEST_AUTH_KEY);
+		given(billingRepository.findByCustomerIdOrThrow(anyString()))
+				.willThrow(new BillingException(NOT_FOUND_BILLING));
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> billingService.updateCard(createOrUpdateCardRequestDTO))
+				.isInstanceOf(BillingException.class)
+				.hasMessage(NOT_REGISTERED_CARD_EXCEPTION_MESSAGE);
+	}
+
 	private Member getExpectedMember() {
 		return Member.builder()
 				.email("testEmail")

--- a/nonsoolmate-api/src/test/java/com/nonsoolmate/payment/service/BillingServiceTest.java
+++ b/nonsoolmate-api/src/test/java/com/nonsoolmate/payment/service/BillingServiceTest.java
@@ -198,6 +198,24 @@ class BillingServiceTest {
 				.hasMessage(NOT_REGISTERED_CARD_EXCEPTION_MESSAGE);
 	}
 
+	@Test
+	@DisplayName("사용자가 authKey를 조작하여 카드 변경을 요청하는 경우")
+	void updateCardTestWithWrongAuthKey() {
+		// given
+		CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO =
+				new CreateOrUpdateCardRequestDTO(MEMBER_ID, TEST_FAKE_AUTH_KEY);
+		Member expectedMember = getExpectedMember();
+		Billing expectedBilling = getExpectedBilling(expectedMember);
+		given(billingRepository.findByCustomerIdOrThrow(anyString())).willReturn(expectedBilling);
+		given(tossPaymentService.issueBilling(any(), any()))
+				.willThrow(new BillingException(TOSS_PAYMENT_ISSUE_BILLING));
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> billingService.updateCard(createOrUpdateCardRequestDTO))
+				.isInstanceOf(BillingException.class)
+				.hasMessage(TOSS_PAYMENT_ISSUE_BILLING_EXCEPTION_MESSAGE);
+	}
+
 	private Member getExpectedMember() {
 		return Member.builder()
 				.email("testEmail")

--- a/nonsoolmate-api/src/test/java/com/nonsoolmate/payment/service/BillingServiceTest.java
+++ b/nonsoolmate-api/src/test/java/com/nonsoolmate/payment/service/BillingServiceTest.java
@@ -183,6 +183,21 @@ class BillingServiceTest {
 				.hasMessage(NOT_REGISTERED_CARD_EXCEPTION_MESSAGE);
 	}
 
+	@Test
+	@DisplayName("사용자가 customerKey를 조작하여 카드 변경을 요청하는 경우")
+	void updateCardTestWithWrongCustomerKey() {
+		// given
+		CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO =
+				new CreateOrUpdateCardRequestDTO(FAKE_MEMBER_ID, TEST_AUTH_KEY);
+		given(billingRepository.findByCustomerIdOrThrow(anyString()))
+				.willThrow(new BillingException(NOT_FOUND_BILLING));
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> billingService.updateCard(createOrUpdateCardRequestDTO))
+				.isInstanceOf(BillingException.class)
+				.hasMessage(NOT_REGISTERED_CARD_EXCEPTION_MESSAGE);
+	}
+
 	private Member getExpectedMember() {
 		return Member.builder()
 				.email("testEmail")

--- a/nonsoolmate-api/src/test/java/com/nonsoolmate/payment/service/BillingServiceTest.java
+++ b/nonsoolmate-api/src/test/java/com/nonsoolmate/payment/service/BillingServiceTest.java
@@ -216,6 +216,20 @@ class BillingServiceTest {
 				.hasMessage(TOSS_PAYMENT_ISSUE_BILLING_EXCEPTION_MESSAGE);
 	}
 
+	@Test
+	@DisplayName("사용자가 customerKey와 AuthKey를 조작하여 카드 변경을 요청하는 경우")
+	void updateCardTestWithWrongCustomerKeyAndAuthKey() {
+		CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO =
+				new CreateOrUpdateCardRequestDTO(FAKE_MEMBER_ID, TEST_AUTH_KEY);
+		given(billingRepository.findByCustomerIdOrThrow(anyString()))
+				.willThrow(new BillingException(NOT_FOUND_BILLING));
+
+		// when, then
+		Assertions.assertThatThrownBy(() -> billingService.updateCard(createOrUpdateCardRequestDTO))
+				.isInstanceOf(BillingException.class)
+				.hasMessage(NOT_REGISTERED_CARD_EXCEPTION_MESSAGE);
+	}
+
 	private Member getExpectedMember() {
 		return Member.builder()
 				.email("testEmail")

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/Billing.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/Billing.java
@@ -22,7 +22,10 @@ import com.nonsoolmate.member.entity.Member;
 		uniqueConstraints = {
 			@UniqueConstraint(
 					name = "UK_BILLING_KEY_CUSTOMER_KEY_KEY",
-					columnNames = {"billingKey", "customerKey"})
+					columnNames = {"billingKey", "customerKey"}),
+			@UniqueConstraint(
+					name = "UK_CUSTOMER_KEY",
+					columnNames = {"customerKey"})
 		})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -58,5 +61,12 @@ public class Billing {
 
 	public void updateLastTransactionKey(final String lastTransactionKey) {
 		this.lastTransactionKey = lastTransactionKey;
+	}
+
+	public void updateCardInfo(
+			final String billingKey, final String cardNumber, final String cardCompany) {
+		this.billingKey = billingKey;
+		this.cardNumber = cardNumber;
+		this.cardCompany = cardCompany;
 	}
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#150 -> dev
- closed #150


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 카드 변경 API를 구현했습니다
- 기존 등록 API와 외부 통신하는 함수는 동일하여 authKey를 클라이언트에게 요청드릴 수 없어 테스트 결과에 test code 성공여부 캡쳐본으로 대체했습니다!
- 카드를 변경하기 전 customerKey로 존재하는 billing을 조회하고 토스페이먼츠로부터 받은 값으로 카드정보 및 billingKey를 업데이트합니다
- 기획 요구사항에 따라 사용자 당 하나의 카드만 등록 가능하도록 customerKey를 unique를 추가했습니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="817" alt="image" src="https://github.com/user-attachments/assets/e4684e48-ca2e-40b2-905c-b84da04d539f">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
