### PR TITLE
[FEAT] 카드 등록, 변경 API에서 requestDTO에 customerKey 제외

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardApi.java
@@ -39,7 +39,8 @@ public interface CardApi {
 			})
 	@Operation(summary = "카드 등록 페이지: 사용자 카드 등록", description = "사용자가 이전에 등록한 카드 정보를 조회합니다")
 	ResponseEntity<CardResponseDTO> registerCard(
-			@RequestBody CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO);
+			@RequestBody CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO,
+			@Parameter(hidden = true) @AuthMember String memberId);
 
 	@ApiResponses(
 			value = {
@@ -55,5 +56,6 @@ public interface CardApi {
 			})
 	@Operation(summary = "카드 등록 페이지: 사용자 카드 변경", description = "사용자가 이전에 등록한 카드 정보를 조회합니다")
 	ResponseEntity<CardResponseDTO> updateCard(
-			@RequestBody CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO);
+			@RequestBody CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO,
+			@Parameter(hidden = true) @AuthMember String memberId);
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardController.java
@@ -31,15 +31,17 @@ public class CardController implements CardApi {
 
 	@PostMapping("/register")
 	public ResponseEntity<CardResponseDTO> registerCard(
-			@RequestBody @Valid CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO) {
-		CardResponseDTO response = billingService.registerCard(createOrUpdateCardRequestDTO);
+			@RequestBody @Valid CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO,
+			@AuthMember final String memberId) {
+		CardResponseDTO response = billingService.registerCard(createOrUpdateCardRequestDTO, memberId);
 		return ResponseEntity.ok(response);
 	}
 
 	@PutMapping("/update")
 	public ResponseEntity<CardResponseDTO> updateCard(
-			@RequestBody @Valid CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO) {
-		CardResponseDTO response = billingService.updateCard(createOrUpdateCardRequestDTO);
+			@RequestBody @Valid CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO,
+			@AuthMember final String memberId) {
+		CardResponseDTO response = billingService.updateCard(createOrUpdateCardRequestDTO, memberId);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/dto/request/CreateOrUpdateCardRequestDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/dto/request/CreateOrUpdateCardRequestDTO.java
@@ -7,5 +7,4 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "CreateOrUpdateCardRequestDTO", description = "카드 등록 또는 변경 요청 DTO")
 public record CreateOrUpdateCardRequestDTO(
-		@Parameter(description = "Toss에서 받은 customerKey", required = true) @NotNull String customerKey,
 		@Parameter(description = "Toss에서 받은 authKey", required = true) @NotNull String authKey) {}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/BillingService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/BillingService.java
@@ -29,10 +29,10 @@ public class BillingService {
 	}
 
 	@Transactional
-	public CardResponseDTO registerCard(final CreateOrUpdateCardRequestDTO request) {
-		TossPaymentBillingVO vo =
-				tossPaymentService.issueBilling(request.customerKey(), request.authKey());
-		Member customer = memberRepository.findByMemberIdOrThrow(request.customerKey());
+	public CardResponseDTO registerCard(
+			final CreateOrUpdateCardRequestDTO request, final String memberId) {
+		TossPaymentBillingVO vo = tossPaymentService.issueBilling(memberId, request.authKey());
+		Member customer = memberRepository.findByMemberIdOrThrow(memberId);
 		Billing billing =
 				Billing.builder()
 						.customer(customer)
@@ -48,10 +48,10 @@ public class BillingService {
 	}
 
 	@Transactional
-	public CardResponseDTO updateCard(final CreateOrUpdateCardRequestDTO request) {
-		Billing billing = billingRepository.findByCustomerIdOrThrow(request.customerKey());
-		TossPaymentBillingVO vo =
-				tossPaymentService.issueBilling(request.customerKey(), request.authKey());
+	public CardResponseDTO updateCard(
+			final CreateOrUpdateCardRequestDTO request, final String memberId) {
+		Billing billing = billingRepository.findByCustomerIdOrThrow(memberId);
+		TossPaymentBillingVO vo = tossPaymentService.issueBilling(memberId, request.authKey());
 		billing.updateCardInfo(vo.billingKey(), vo.cardNumber(), vo.cardCompany());
 
 		return CardResponseDTO.of(


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 변경
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#152 -> dev
- closed #152

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
#151 해당 PR에서 리뷰받은 내용을 반영하였습니다
- dto에서 customerKey를 제외하면서 customerKey가 조작되는 상황은 토큰이 조작되는 상황이라고 생각해 테스트의 책임이 BillingServiceTest가 아니라고 생각하여 제외했습니다!

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![image](https://github.com/user-attachments/assets/bcccab01-bb80-42e4-9dfa-e1e9ea4972ca)

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
