### PR TITLE
[FEAT] 결제 API 구현

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/coupon/controller/dto/request/IssueCouponRequestDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/coupon/controller/dto/request/IssueCouponRequestDTO.java
@@ -21,7 +21,7 @@ public class IssueCouponRequestDTO {
 	private final String couponImageUrl;
 	private final String couponNumber;
 	@NotNull private final CouponType couponType;
-	private final int discountRate;
+	private final double discountRate;
 	private final int discountAmount;
 	private final int ticketCount;
 	private final LocalDateTime validStartDate;

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/coupon/controller/dto/response/GetCouponResponseDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/coupon/controller/dto/response/GetCouponResponseDTO.java
@@ -29,8 +29,8 @@ public class GetCouponResponseDTO {
 	@Schema(description = "쿠폰 타입, </br> RATE, AMOUNT, EDIT_TICKET 중에 하나입니다.", example = "RATE")
 	private final CouponType couponType;
 
-	@Schema(description = "RATE 일 경우 할인율", example = "20")
-	private final int discountRate;
+	@Schema(description = "RATE 일 경우 할인율", example = "0.2")
+	private final double discountRate;
 
 	@Schema(description = "AMOUNT 일 경우 할인금액", example = "30000")
 	private final int discountAmount;

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/couponMember/service/CouponMemberService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/couponMember/service/CouponMemberService.java
@@ -7,7 +7,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.nonsoolmate.coupon.entity.Coupon;
 import com.nonsoolmate.coupon.repository.CouponRepository;
+<<<<<<< HEAD
 import com.nonsoolmate.couponMember.entity.CouponMember;
+=======
+>>>>>>> c702253 ([FEAT] CouponMemberService에 validateCoupon 구현)
 import com.nonsoolmate.couponMember.repository.CouponMemberRepository;
 
 @Service
@@ -17,11 +20,17 @@ public class CouponMemberService {
 	private final CouponMemberRepository couponMemberRepository;
 	private final CouponRepository couponRepository;
 
+<<<<<<< HEAD
 	public CouponMember validateCoupon(final Long couponMemberId, final String memberId) {
 		return couponMemberRepository.findByCouponMemberIdAndMemberIdThrow(couponMemberId, memberId);
 	}
 
 	public Coupon getCoupon(final Long couponId) {
+=======
+	public Coupon validateCoupon(final Long couponMemberId, final String memberId) {
+		Long couponId =
+				couponMemberRepository.findByCouponMemberIdAndMemberIdThrow(couponMemberId, memberId);
+>>>>>>> c702253 ([FEAT] CouponMemberService에 validateCoupon 구현)
 		return couponRepository.findByCouponIdOrThrow(couponId);
 	}
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/couponMember/service/CouponMemberService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/couponMember/service/CouponMemberService.java
@@ -7,10 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.nonsoolmate.coupon.entity.Coupon;
 import com.nonsoolmate.coupon.repository.CouponRepository;
-<<<<<<< HEAD
 import com.nonsoolmate.couponMember.entity.CouponMember;
-=======
->>>>>>> c702253 ([FEAT] CouponMemberService에 validateCoupon 구현)
 import com.nonsoolmate.couponMember.repository.CouponMemberRepository;
 
 @Service
@@ -20,17 +17,11 @@ public class CouponMemberService {
 	private final CouponMemberRepository couponMemberRepository;
 	private final CouponRepository couponRepository;
 
-<<<<<<< HEAD
 	public CouponMember validateCoupon(final Long couponMemberId, final String memberId) {
 		return couponMemberRepository.findByCouponMemberIdAndMemberIdThrow(couponMemberId, memberId);
 	}
 
 	public Coupon getCoupon(final Long couponId) {
-=======
-	public Coupon validateCoupon(final Long couponMemberId, final String memberId) {
-		Long couponId =
-				couponMemberRepository.findByCouponMemberIdAndMemberIdThrow(couponMemberId, memberId);
->>>>>>> c702253 ([FEAT] CouponMemberService에 validateCoupon 구현)
 		return couponRepository.findByCouponIdOrThrow(couponId);
 	}
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/couponMember/service/CouponMemberService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/couponMember/service/CouponMemberService.java
@@ -1,0 +1,24 @@
+package com.nonsoolmate.couponMember.service;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nonsoolmate.coupon.entity.Coupon;
+import com.nonsoolmate.coupon.repository.CouponRepository;
+import com.nonsoolmate.couponMember.repository.CouponMemberRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CouponMemberService {
+	private final CouponMemberRepository couponMemberRepository;
+	private final CouponRepository couponRepository;
+
+	public Coupon validateCoupon(final Long couponMemberId, final String memberId) {
+		Long couponId =
+				couponMemberRepository.findByCouponMemberIdAndMemberIdThrow(couponMemberId, memberId);
+		return couponRepository.findByCouponIdOrThrow(couponId);
+	}
+}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/couponMember/service/CouponMemberService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/couponMember/service/CouponMemberService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.nonsoolmate.coupon.entity.Coupon;
 import com.nonsoolmate.coupon.repository.CouponRepository;
+import com.nonsoolmate.couponMember.entity.CouponMember;
 import com.nonsoolmate.couponMember.repository.CouponMemberRepository;
 
 @Service
@@ -16,9 +17,11 @@ public class CouponMemberService {
 	private final CouponMemberRepository couponMemberRepository;
 	private final CouponRepository couponRepository;
 
-	public Coupon validateCoupon(final Long couponMemberId, final String memberId) {
-		Long couponId =
-				couponMemberRepository.findByCouponMemberIdAndMemberIdThrow(couponMemberId, memberId);
+	public CouponMember validateCoupon(final Long couponMemberId, final String memberId) {
+		return couponMemberRepository.findByCouponMemberIdAndMemberIdThrow(couponMemberId, memberId);
+	}
+
+	public Coupon getCoupon(final Long couponId) {
 		return couponRepository.findByCouponIdOrThrow(couponId);
 	}
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/discountProduct/service/DiscountProductService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/discountProduct/service/DiscountProductService.java
@@ -1,0 +1,57 @@
+package com.nonsoolmate.discountProduct.service;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nonsoolmate.discount.entity.Discount;
+import com.nonsoolmate.discountProduct.DiscountProductRepository;
+import com.nonsoolmate.discountProduct.entity.DiscountProduct;
+import com.nonsoolmate.payment.repository.TransactionDetailRepository;
+import com.nonsoolmate.product.entity.Product;
+import com.nonsoolmate.product.repository.ProductRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DiscountProductService {
+	private final TransactionDetailRepository transactionDetailRepository;
+	private final DiscountProductRepository discountProductRepository;
+	private final ProductRepository productRepository;
+
+	private static final double NOT_FIRST_PURCHASE_DISCOUNT_RATE = 0.0;
+
+	public long getDiscountedProductPrice(final Long productId, final String memberId) {
+		Product product = productRepository.findByProductIdOrThrow(productId);
+		double discountedPrice = product.getPrice();
+
+		List<DiscountProduct> discountProducts = discountProductRepository.findAllByProductId(product);
+		boolean isFirstPurchaseMember = isFirstPurchase(memberId);
+
+		for (DiscountProduct discountProduct : discountProducts) {
+			Discount discount = discountProduct.getDiscount();
+			double discountPercent = getDiscountPercent(discount, isFirstPurchaseMember);
+			discountedPrice *= (1.0 - discountPercent);
+		}
+
+		return Math.round(discountedPrice);
+	}
+
+	private double getDiscountPercent(final Discount discount, final boolean isFirstPurchaseMember) {
+		switch (discount.getDiscountType()) {
+			case FIRST_PURCHASE:
+				return isFirstPurchaseMember
+						? discount.getDiscountRate()
+						: NOT_FIRST_PURCHASE_DISCOUNT_RATE;
+			default:
+				return discount.getDiscountRate();
+		}
+	}
+
+	private boolean isFirstPurchase(final String memberId) {
+		return !transactionDetailRepository.existsByCustomerKey(memberId);
+	}
+}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/discountProduct/service/DiscountProductService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/discountProduct/service/DiscountProductService.java
@@ -10,7 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.nonsoolmate.discount.entity.Discount;
 import com.nonsoolmate.discountProduct.DiscountProductRepository;
 import com.nonsoolmate.discountProduct.entity.DiscountProduct;
-import com.nonsoolmate.payment.repository.TransactionDetailRepository;
+import com.nonsoolmate.payment.service.TransactionService;
 import com.nonsoolmate.product.entity.Product;
 import com.nonsoolmate.product.repository.ProductRepository;
 
@@ -18,9 +18,9 @@ import com.nonsoolmate.product.repository.ProductRepository;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class DiscountProductService {
-	private final TransactionDetailRepository transactionDetailRepository;
 	private final DiscountProductRepository discountProductRepository;
 	private final ProductRepository productRepository;
+	private final TransactionService transactionService;
 
 	private static final double NOT_FIRST_PURCHASE_DISCOUNT_RATE = 0.0;
 
@@ -29,7 +29,7 @@ public class DiscountProductService {
 		double discountedPrice = product.getPrice();
 
 		List<DiscountProduct> discountProducts = discountProductRepository.findAllByProductId(product);
-		boolean isFirstPurchaseMember = isFirstPurchase(memberId);
+		boolean isFirstPurchaseMember = transactionService.isFirstPurchase(memberId);
 
 		for (DiscountProduct discountProduct : discountProducts) {
 			Discount discount = discountProduct.getDiscount();
@@ -49,9 +49,5 @@ public class DiscountProductService {
 			default:
 				return discount.getDiscountRate();
 		}
-	}
-
-	private boolean isFirstPurchase(final String memberId) {
-		return !transactionDetailRepository.existsByCustomerKey(memberId);
 	}
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/service/MembershipService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/service/MembershipService.java
@@ -33,4 +33,10 @@ public class MembershipService {
 		boolean existMembership = membershipType != null;
 		return existMembership ? membershipType : MembershipType.NONE;
 	}
+
+	public boolean checkMembership(final String memberId) {
+		Member member = memberRepository.findByMemberIdOrThrow(memberId);
+		MembershipType membershipType = getMembershipType(member);
+		return membershipType != MembershipType.NONE;
+	}
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/service/MembershipService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/service/MembershipService.java
@@ -7,9 +7,11 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.nonsoolmate.member.controller.dto.response.MembershipAndTicketResponseDTO;
 import com.nonsoolmate.member.entity.Member;
+import com.nonsoolmate.member.entity.Membership;
 import com.nonsoolmate.member.entity.enums.MembershipType;
 import com.nonsoolmate.member.repository.MemberRepository;
 import com.nonsoolmate.member.repository.MembershipRepository;
+import com.nonsoolmate.product.entity.Product;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +19,9 @@ import com.nonsoolmate.member.repository.MembershipRepository;
 public class MembershipService {
 	private final MemberRepository memberRepository;
 	private final MembershipRepository membershipRepository;
+
+	private final String BASIC_MEMBERSHIP_TYPE_NAME = "베이직 플랜";
+	private final String PREMIUM_MEMBERSHIP_TYPE_NAME = "프리미엄 플랜";
 
 	public MembershipAndTicketResponseDTO getMembershipAndTicket(final String memberId) {
 		Member member = memberRepository.findByMemberIdOrThrow(memberId);
@@ -38,5 +43,24 @@ public class MembershipService {
 		Member member = memberRepository.findByMemberIdOrThrow(memberId);
 		MembershipType membershipType = getMembershipType(member);
 		return membershipType != MembershipType.NONE;
+	}
+
+	public Membership createMembership(final String memberId, final Product product) {
+		Member member = memberRepository.findByMemberIdOrThrow(memberId);
+		MembershipType membershipType = getMembershipTypeByProduct(product);
+		Membership membership =
+				Membership.builder().member(member).membershipType(membershipType).build();
+		return membershipRepository.save(membership);
+	}
+
+	private MembershipType getMembershipTypeByProduct(final Product product) {
+		switch (product.getProductName()) {
+			case BASIC_MEMBERSHIP_TYPE_NAME:
+				return MembershipType.BASIC;
+			case PREMIUM_MEMBERSHIP_TYPE_NAME:
+				return MembershipType.PREMIUM;
+			default:
+				return MembershipType.NONE;
+		}
 	}
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/order/service/OrderService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/order/service/OrderService.java
@@ -1,0 +1,58 @@
+package com.nonsoolmate.order.service;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nonsoolmate.coupon.entity.Coupon;
+import com.nonsoolmate.couponMember.entity.CouponMember;
+import com.nonsoolmate.couponMember.service.CouponMemberService;
+import com.nonsoolmate.discountProduct.service.DiscountProductService;
+import com.nonsoolmate.member.entity.Member;
+import com.nonsoolmate.member.repository.MemberRepository;
+import com.nonsoolmate.order.entity.OrderDetail;
+import com.nonsoolmate.order.repository.OrderRepository;
+import com.nonsoolmate.payment.controller.dto.request.CreatePaymentRequestDTO;
+import com.nonsoolmate.product.entity.Product;
+import com.nonsoolmate.product.repository.ProductRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+	private final OrderRepository orderRepository;
+	private final MemberRepository memberRepository;
+	private final ProductRepository productRepository;
+	private final DiscountProductService discountProductService;
+	private final CouponMemberService couponMemberService;
+
+	@Transactional
+	public OrderDetail createOrder(final CreatePaymentRequestDTO request, final String memberId) {
+		Member member = memberRepository.findByMemberIdOrThrow(memberId);
+		CouponMember validCouponMember =
+				couponMemberService.validateCoupon(request.couponMemberId(), memberId);
+		Product product = productRepository.findByProductIdOrThrow(request.productId());
+		long discountedProductPrice =
+				discountProductService.getDiscountedProductPrice(product.getProductId(), memberId);
+		Coupon validCoupon = couponMemberService.getCoupon(validCouponMember.getCouponId());
+		long orderAmount = calculateOrderAmountWithCoupon(discountedProductPrice, validCoupon);
+
+		OrderDetail order =
+				OrderDetail.builder()
+						.orderName(product.getProductName())
+						.member(member)
+						.product(product)
+						.couponMember(validCouponMember)
+						.amount(orderAmount)
+						.build();
+
+		return orderRepository.save(order);
+	}
+
+	private long calculateOrderAmountWithCoupon(
+			final double discountedProductPrice, final Coupon validCoupon) {
+		double couponAppliedPrice = discountedProductPrice * (1 - validCoupon.getDiscountRate());
+		return Math.round(couponAppliedPrice);
+	}
+}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/PaymentApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/PaymentApi.java
@@ -3,10 +3,15 @@ package com.nonsoolmate.payment.controller;
 import org.springframework.http.ResponseEntity;
 
 import com.nonsoolmate.global.security.AuthMember;
+import com.nonsoolmate.payment.controller.dto.request.CreatePaymentRequestDTO;
 import com.nonsoolmate.payment.controller.dto.response.CustomerInfoDTO;
+import com.nonsoolmate.payment.controller.dto.response.PaymentResponseDTO;
+import com.nonsoolmate.response.ErrorResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,4 +24,24 @@ public interface PaymentApi {
 			description = "결제 위젯 호출을 위해 customer의 customerKey, name, email을 조회합니다.")
 	ResponseEntity<CustomerInfoDTO> getCustomerInfo(
 			@Parameter(hidden = true) @AuthMember String memberId);
+
+	@ApiResponses(
+			value = {
+				@ApiResponse(responseCode = "201", description = "결제에 성공한 경우"),
+				@ApiResponse(
+						responseCode = "400",
+						description = "사용자가 사용할 수 있는 couponMemberId를 보내지 않은 경우",
+						content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+				@ApiResponse(
+						responseCode = "400",
+						description = "유효하지 않은 productId(상품 id)를 보낸 경우",
+						content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+				@ApiResponse(
+						responseCode = "400",
+						description = "이미 멤버십을 구독하고 있는 경우",
+						content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+			})
+	@Operation(summary = "결제 페이지: 멤버십 상품 결제", description = "결제 페이지: 멤버십 상품을 결제하는 경우")
+	ResponseEntity<PaymentResponseDTO> createMembershipPayment(
+			CreatePaymentRequestDTO paymentRequestDTO, @Parameter(hidden = true) String memberId);
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/PaymentApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/PaymentApi.java
@@ -39,6 +39,10 @@ public interface PaymentApi {
 				@ApiResponse(
 						responseCode = "400",
 						description = "이미 멤버십을 구독하고 있는 경우",
+						content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+				@ApiResponse(
+						responseCode = "404",
+						description = "카드 등록을 하지 않고 결제를 시도한 경우",
 						content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
 			})
 	@Operation(summary = "결제 페이지: 멤버십 상품 결제", description = "결제 페이지: 멤버십 상품을 결제하는 경우")

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/PaymentController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/PaymentController.java
@@ -1,27 +1,44 @@
 package com.nonsoolmate.payment.controller;
 
+import java.net.URI;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nonsoolmate.global.security.AuthMember;
 import com.nonsoolmate.member.service.MemberService;
+import com.nonsoolmate.payment.controller.dto.request.CreatePaymentRequestDTO;
 import com.nonsoolmate.payment.controller.dto.response.CustomerInfoDTO;
+import com.nonsoolmate.payment.controller.dto.response.PaymentResponseDTO;
+import com.nonsoolmate.payment.service.PaymentService;
 
 @RestController
 @Slf4j
 @RequestMapping("/payment")
 @RequiredArgsConstructor
 public class PaymentController implements PaymentApi {
-
+	private static final String PAYMENT_URL = "/payment/";
 	private final MemberService memberService;
+	private final PaymentService paymentService;
 
 	@GetMapping("/customer/info")
-	public ResponseEntity<CustomerInfoDTO> getCustomerInfo(@AuthMember String memberId) {
+	public ResponseEntity<CustomerInfoDTO> getCustomerInfo(@AuthMember final String memberId) {
 		return ResponseEntity.ok().body(memberService.getCustomerInfo(memberId));
+	}
+
+	@PostMapping("/membership")
+	public ResponseEntity<PaymentResponseDTO> createMembershipPayment(
+			@RequestBody final CreatePaymentRequestDTO paymentRequestDTO,
+			@AuthMember final String memberId) {
+		PaymentResponseDTO response = paymentService.createBillingPayment(paymentRequestDTO, memberId);
+		URI uri = URI.create(PAYMENT_URL + response.paymentId());
+		return ResponseEntity.created(uri).body(response);
 	}
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/PaymentController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/PaymentController.java
@@ -2,6 +2,8 @@ package com.nonsoolmate.payment.controller;
 
 import java.net.URI;
 
+import jakarta.validation.Valid;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,7 +37,7 @@ public class PaymentController implements PaymentApi {
 
 	@PostMapping("/membership")
 	public ResponseEntity<PaymentResponseDTO> createMembershipPayment(
-			@RequestBody final CreatePaymentRequestDTO paymentRequestDTO,
+			@Valid @RequestBody final CreatePaymentRequestDTO paymentRequestDTO,
 			@AuthMember final String memberId) {
 		PaymentResponseDTO response = paymentService.createBillingPayment(paymentRequestDTO, memberId);
 		URI uri = URI.create(PAYMENT_URL + response.paymentId());

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/dto/request/CreatePaymentRequestDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/dto/request/CreatePaymentRequestDTO.java
@@ -1,0 +1,12 @@
+package com.nonsoolmate.payment.controller.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "CreatePaymentRequestDTO", description = "상품 결제 요청 DTO")
+public record CreatePaymentRequestDTO(
+		@Parameter(description = "구매하는 상품 id", required = true) @NotNull Long productId,
+		@Parameter(description = "사용자가 적용한 couponMemberId", required = true) @NotNull
+				Long couponMemberId) {}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/dto/request/CreatePaymentRequestDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/dto/request/CreatePaymentRequestDTO.java
@@ -8,5 +8,4 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(name = "CreatePaymentRequestDTO", description = "상품 결제 요청 DTO")
 public record CreatePaymentRequestDTO(
 		@Parameter(description = "구매하는 상품 id", required = true) @NotNull Long productId,
-		@Parameter(description = "사용자가 적용한 couponMemberId", required = true) @NotNull
-				Long couponMemberId) {}
+		@Parameter(description = "사용자가 적용한 couponMemberId") Long couponMemberId) {}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/dto/response/PaymentResponseDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/dto/response/PaymentResponseDTO.java
@@ -7,4 +7,8 @@ public record PaymentResponseDTO(
 		/**
 		 * @note: paymentId = Transaction_Detail.transactionKey
 		 */
-		@Schema(description = "결제 완료 이후 반환되는 paymentId", example = "edslskdkdksl") String paymentId) {}
+		@Schema(description = "결제 완료 이후 반환되는 paymentId", example = "edslskdkdksl") String paymentId) {
+	public static PaymentResponseDTO of(String paymentId) {
+		return new PaymentResponseDTO(paymentId);
+	}
+}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/dto/response/PaymentResponseDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/dto/response/PaymentResponseDTO.java
@@ -1,0 +1,10 @@
+package com.nonsoolmate.payment.controller.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "PaymentResponseDTO", description = "결제 요청에 대한 응답 DTO")
+public record PaymentResponseDTO(
+		/**
+		 * @note: paymentId = Transaction_Detail.transactionKey
+		 */
+		@Schema(description = "결제 완료 이후 반환되는 paymentId", example = "edslskdkdksl") String paymentId) {}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/BillingService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/BillingService.java
@@ -57,4 +57,9 @@ public class BillingService {
 		return CardResponseDTO.of(
 				billing.getBillingId(), billing.getCardCompany(), billing.getCardNumber());
 	}
+
+	public String getBillingKey(final String customerKey) {
+		Billing billing = billingRepository.findByCustomerIdOrThrow(customerKey);
+		return billing.getBillingKey();
+	}
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/BillingService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/BillingService.java
@@ -12,7 +12,7 @@ import com.nonsoolmate.payment.controller.dto.response.CardResponseDTO;
 import com.nonsoolmate.payment.entity.Billing;
 import com.nonsoolmate.payment.repository.BillingRepository;
 import com.nonsoolmate.toss.service.TossPaymentService;
-import com.nonsoolmate.toss.service.vo.TossPaymentBillingVO;
+import com.nonsoolmate.toss.service.vo.TossPaymentBillingKeyVO;
 
 @Service
 @RequiredArgsConstructor
@@ -31,7 +31,7 @@ public class BillingService {
 	@Transactional
 	public CardResponseDTO registerCard(
 			final CreateOrUpdateCardRequestDTO request, final String memberId) {
-		TossPaymentBillingVO vo = tossPaymentService.issueBilling(memberId, request.authKey());
+		TossPaymentBillingKeyVO vo = tossPaymentService.issueBillingKey(memberId, request.authKey());
 		Member customer = memberRepository.findByMemberIdOrThrow(memberId);
 		Billing billing =
 				Billing.builder()
@@ -51,7 +51,7 @@ public class BillingService {
 	public CardResponseDTO updateCard(
 			final CreateOrUpdateCardRequestDTO request, final String memberId) {
 		Billing billing = billingRepository.findByCustomerIdOrThrow(memberId);
-		TossPaymentBillingVO vo = tossPaymentService.issueBilling(memberId, request.authKey());
+		TossPaymentBillingKeyVO vo = tossPaymentService.issueBillingKey(memberId, request.authKey());
 		billing.updateCardInfo(vo.billingKey(), vo.cardNumber(), vo.cardCompany());
 
 		return CardResponseDTO.of(

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/PaymentService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/PaymentService.java
@@ -1,0 +1,47 @@
+package com.nonsoolmate.payment.service;
+
+import static com.nonsoolmate.exception.payment.BillingExceptionType.*;
+import static com.nonsoolmate.exception.payment.PaymentExceptionType.*;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nonsoolmate.exception.payment.PaymentException;
+import com.nonsoolmate.member.service.MembershipService;
+import com.nonsoolmate.order.entity.OrderDetail;
+import com.nonsoolmate.order.service.OrderService;
+import com.nonsoolmate.payment.controller.dto.request.CreatePaymentRequestDTO;
+import com.nonsoolmate.payment.controller.dto.response.PaymentResponseDTO;
+import com.nonsoolmate.toss.service.TossPaymentService;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentService {
+	private final OrderService orderService;
+	private final MembershipService membershipService;
+	private final TossPaymentService tossPaymentService;
+
+	@Transactional
+	public PaymentResponseDTO createMembershipPayment(
+			final CreatePaymentRequestDTO request, final String memberId) {
+
+		validateMembership(memberId);
+
+		OrderDetail order = orderService.createOrder(request, memberId);
+		// TransactionVO transaction = tossPaymentService.requestPayment(order, memberId);
+		// TransactionService.createTransaction(transaction);
+		// // TODO Auto-generated method stub
+		// return PaymentResponseDTO.of(transaction.getTransacionKey());
+		return null;
+	}
+
+	private void validateMembership(final String memberId) {
+		boolean hasMembership = membershipService.checkMembership(memberId);
+		if (hasMembership) {
+			throw new PaymentException(ALREADY_MEMBERSHIP_BILLING);
+		}
+	}
+}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/PaymentService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/PaymentService.java
@@ -28,6 +28,8 @@ public class PaymentService {
 	private final BillingService billingService;
 	private final TransactionService transactionService;
 
+	private static final Long NO_COUPON_MEMBER_ID = null;
+
 	@Transactional
 	public PaymentResponseDTO createBillingPayment(
 			final CreatePaymentRequestDTO request, final String memberId) {
@@ -47,6 +49,9 @@ public class PaymentService {
 						tossPaymentTransactionVO.transactionAt());
 		TransactionDetail transaction = transactionService.createTransaction(transactionVO);
 		membershipService.createMembership(memberId, order.getProduct());
+		// create next month order
+		orderService.createOrder(request.productId(), NO_COUPON_MEMBER_ID, memberId);
+
 		return PaymentResponseDTO.of(transaction.getTransactionKey());
 	}
 

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/TransactionService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/TransactionService.java
@@ -1,0 +1,34 @@
+package com.nonsoolmate.payment.service;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nonsoolmate.payment.entity.TransactionDetail;
+import com.nonsoolmate.payment.repository.TransactionDetailRepository;
+import com.nonsoolmate.payment.service.vo.TransactionVO;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TransactionService {
+	private final TransactionDetailRepository transactionRepository;
+
+	@Transactional
+	public TransactionDetail createTransaction(final TransactionVO transactionVO) {
+		TransactionDetail transaction =
+				TransactionDetail.builder()
+						.transactionKey(transactionVO.transactionKey())
+						.paymentKey(transactionVO.paymentKey())
+						.customerKey(transactionVO.customerKey())
+						.order(transactionVO.order())
+						.transactionAt(transactionVO.transactionAt())
+						.build();
+		return transactionRepository.save(transaction);
+	}
+
+	public boolean isFirstPurchase(final String memberId) {
+		return !transactionRepository.existsByCustomerKey(memberId);
+	}
+}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/TransactionService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/TransactionService.java
@@ -23,6 +23,7 @@ public class TransactionService {
 						.paymentKey(transactionVO.paymentKey())
 						.customerKey(transactionVO.customerKey())
 						.order(transactionVO.order())
+						.receiptUrl(transactionVO.receiptUrl())
 						.transactionAt(transactionVO.transactionAt())
 						.build();
 		return transactionRepository.save(transaction);

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/vo/TransactionVO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/vo/TransactionVO.java
@@ -1,0 +1,24 @@
+package com.nonsoolmate.payment.service.vo;
+
+import java.time.LocalDateTime;
+
+import com.nonsoolmate.order.entity.OrderDetail;
+
+public record TransactionVO(
+		String transactionKey,
+		String paymentKey,
+		String customerKey,
+		OrderDetail order,
+		String receiptUrl,
+		LocalDateTime transactionAt) {
+	public static TransactionVO of(
+			String transactionKey,
+			String paymentKey,
+			String customerKey,
+			OrderDetail order,
+			String receiptUrl,
+			LocalDateTime transactionAt) {
+		return new TransactionVO(
+				transactionKey, paymentKey, customerKey, order, receiptUrl, transactionAt);
+	}
+}

--- a/nonsoolmate-api/src/test/java/com/nonsoolmate/payment/service/BillingServiceTest.java
+++ b/nonsoolmate-api/src/test/java/com/nonsoolmate/payment/service/BillingServiceTest.java
@@ -1,6 +1,5 @@
 package com.nonsoolmate.payment.service;
 
-import static com.nonsoolmate.exception.member.MemberExceptionType.*;
 import static com.nonsoolmate.exception.payment.BillingExceptionType.*;
 import static org.mockito.BDDMockito.*;
 
@@ -22,7 +21,7 @@ import com.nonsoolmate.payment.controller.dto.response.CardResponseDTO;
 import com.nonsoolmate.payment.entity.Billing;
 import com.nonsoolmate.payment.repository.BillingRepository;
 import com.nonsoolmate.toss.service.TossPaymentService;
-import com.nonsoolmate.toss.service.vo.TossPaymentBillingVO;
+import com.nonsoolmate.toss.service.vo.TossPaymentBillingKeyVO;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -78,14 +77,14 @@ class BillingServiceTest {
 		Member expectedMember = getExpectedMember();
 		CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO =
 				new CreateOrUpdateCardRequestDTO(TEST_AUTH_KEY);
-		TossPaymentBillingVO mockTossPaymentBillingVO =
-				TossPaymentBillingVO.of(
+		TossPaymentBillingKeyVO mockTossPaymentBillingKeyVO =
+				TossPaymentBillingKeyVO.of(
 						expectedMember.getMemberId(), TEST_BILLING_KEY, TEST_CARD_COMPANY, TEST_CARD_NUMBER);
 		Billing expectedBilling = getExpectedBilling(expectedMember);
 		CardResponseDTO expectedResponse = getExpectedCardResponseDTO(expectedBilling);
 
 		given(memberRepository.findByMemberIdOrThrow(anyString())).willReturn(expectedMember);
-		given(tossPaymentService.issueBilling(any(), any())).willReturn(mockTossPaymentBillingVO);
+		given(tossPaymentService.issueBillingKey(any(), any())).willReturn(mockTossPaymentBillingKeyVO);
 		given(billingRepository.save(any())).willReturn(expectedBilling);
 
 		// when
@@ -103,7 +102,7 @@ class BillingServiceTest {
 				new CreateOrUpdateCardRequestDTO(TEST_FAKE_AUTH_KEY);
 		Member expectedMember = getExpectedMember();
 		given(memberRepository.findByMemberIdOrThrow(anyString())).willReturn(expectedMember);
-		given(tossPaymentService.issueBilling(any(), any()))
+		given(tossPaymentService.issueBillingKey(any(), any()))
 				.willThrow(new BillingException(TOSS_PAYMENT_ISSUE_BILLING));
 
 		// when, then
@@ -121,14 +120,14 @@ class BillingServiceTest {
 
 		CreateOrUpdateCardRequestDTO createOrUpdateCardRequestDTO =
 				new CreateOrUpdateCardRequestDTO(TEST_AUTH_KEY);
-		TossPaymentBillingVO mockTossPaymentBillingVO =
-				TossPaymentBillingVO.of(
+		TossPaymentBillingKeyVO mockTossPaymentBillingKeyVO =
+				TossPaymentBillingKeyVO.of(
 						expectedMember.getMemberId(), TEST_BILLING_KEY, TEST_CARD_COMPANY, TEST_CARD_NUMBER);
 		Billing expectedBilling = getExpectedBilling(expectedMember);
 		CardResponseDTO expectedResponse = getExpectedCardResponseDTO(expectedBilling);
 
 		given(billingRepository.findByCustomerIdOrThrow(anyString())).willReturn(expectedBilling);
-		given(tossPaymentService.issueBilling(any(), any())).willReturn(mockTossPaymentBillingVO);
+		given(tossPaymentService.issueBillingKey(any(), any())).willReturn(mockTossPaymentBillingKeyVO);
 
 		// when
 		CardResponseDTO response = billingService.updateCard(createOrUpdateCardRequestDTO, MEMBER_ID);
@@ -162,7 +161,7 @@ class BillingServiceTest {
 		Member expectedMember = getExpectedMember();
 		Billing expectedBilling = getExpectedBilling(expectedMember);
 		given(billingRepository.findByCustomerIdOrThrow(anyString())).willReturn(expectedBilling);
-		given(tossPaymentService.issueBilling(any(), any()))
+		given(tossPaymentService.issueBillingKey(any(), any()))
 				.willThrow(new BillingException(TOSS_PAYMENT_ISSUE_BILLING));
 
 		// when, then

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/coupon/CouponExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/coupon/CouponExceptionType.java
@@ -11,7 +11,8 @@ import com.nonsoolmate.exception.common.ExceptionType;
 public enum CouponExceptionType implements ExceptionType {
 	INVALID_COUPON_REGISTER(HttpStatus.BAD_REQUEST, "이미 등록된 쿠폰입니다."),
 	INVALID_COUPON_ISSUE(HttpStatus.BAD_REQUEST, "올바르지 않는 요청입니다."),
-	NOT_FOUND_COUPON(HttpStatus.NOT_FOUND, "유효한 쿠폰을 찾을 수 없습니다.");
+	NOT_FOUND_COUPON(HttpStatus.NOT_FOUND, "유효한 쿠폰을 찾을 수 없습니다."),
+	INVALID_COUPON(HttpStatus.BAD_REQUEST, "유효하지 않은 쿠폰입니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/payment/PaymentException.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/payment/PaymentException.java
@@ -1,0 +1,10 @@
+package com.nonsoolmate.exception.payment;
+
+import com.nonsoolmate.exception.common.ClientException;
+import com.nonsoolmate.exception.common.ExceptionType;
+
+public class PaymentException extends ClientException {
+	public PaymentException(ExceptionType exceptionType) {
+		super(exceptionType);
+	}
+}

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/payment/PaymentExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/payment/PaymentExceptionType.java
@@ -1,0 +1,27 @@
+package com.nonsoolmate.exception.payment;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+
+import com.nonsoolmate.exception.common.ExceptionType;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum PaymentExceptionType implements ExceptionType {
+	ALREADY_MEMBERSHIP_BILLING(HttpStatus.BAD_REQUEST, "이미 멤버십 결제가 진행중입니다");
+	;
+
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public HttpStatus status() {
+		return this.status;
+	}
+
+	@Override
+	public String message() {
+		return this.message;
+	}
+}

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/product/ProductException.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/product/ProductException.java
@@ -1,0 +1,10 @@
+package com.nonsoolmate.exception.product;
+
+import com.nonsoolmate.exception.common.ClientException;
+import com.nonsoolmate.exception.common.ExceptionType;
+
+public class ProductException extends ClientException {
+	public ProductException(ExceptionType exceptionType) {
+		super(exceptionType);
+	}
+}

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/product/ProductExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/product/ProductExceptionType.java
@@ -1,0 +1,26 @@
+package com.nonsoolmate.exception.product;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+
+import com.nonsoolmate.exception.common.ExceptionType;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum ProductExceptionType implements ExceptionType {
+	INVALID_PRODUCT_ID(HttpStatus.BAD_REQUEST, "유효한 상품 id가 아닙니다");
+
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public HttpStatus status() {
+		return this.status;
+	}
+
+	@Override
+	public String message() {
+		return this.message;
+	}
+}

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/coupon/entity/Coupon.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/coupon/entity/Coupon.java
@@ -61,7 +61,7 @@ public class Coupon extends BaseTimeEntity {
 			String couponImageUrl,
 			String couponNumber,
 			CouponType couponType,
-			int discountRate,
+			double discountRate,
 			int discountAmount,
 			int ticketCount,
 			LocalDateTime validStartDate,

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/coupon/entity/Coupon.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/coupon/entity/Coupon.java
@@ -44,7 +44,7 @@ public class Coupon extends BaseTimeEntity {
 	/**
 	 * @note: 쿠폰은 discountRate, discountAmount, ticketCount 중 하나의 깂을 가진다.
 	 */
-	private int discountRate;
+	private double discountRate;
 
 	private int discountAmount;
 

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/coupon/repository/CouponRepository.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/coupon/repository/CouponRepository.java
@@ -16,4 +16,10 @@ public interface CouponRepository extends JpaRepository<Coupon, Long> {
 		return findByCouponNumber(couponNumber)
 				.orElseThrow(() -> new CouponException(NOT_FOUND_COUPON));
 	}
+
+	Optional<Coupon> findByCouponId(Long couponId);
+
+	default Coupon findByCouponIdOrThrow(Long couponId) {
+		return findByCouponId(couponId).orElseThrow(() -> new CouponException(NOT_FOUND_COUPON));
+	}
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/couponMember/repository/CouponMemberRepository.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/couponMember/repository/CouponMemberRepository.java
@@ -15,11 +15,11 @@ public interface CouponMemberRepository
 	Optional<CouponMember> findByCouponId(Long couponId);
 
 	@Query(
-			"SELECT cm.couponId FROM CouponMember cm WHERE cm.couponMemberId = :couponMemberId AND cm.memberId = :memberId")
-	Optional<Long> findCouponIdByCouponMemberIdAndMemberId(
+			"SELECT cm FROM CouponMember cm WHERE cm.couponMemberId = :couponMemberId AND cm.memberId = :memberId")
+	Optional<CouponMember> findCouponIdByCouponMemberIdAndMemberId(
 			final Long couponMemberId, final String memberId);
 
-	default Long findByCouponMemberIdAndMemberIdThrow(
+	default CouponMember findByCouponMemberIdAndMemberIdThrow(
 			final Long couponMemberId, final String memberId) {
 		return findCouponIdByCouponMemberIdAndMemberId(couponMemberId, memberId)
 				.orElseThrow(() -> new CouponException(INVALID_COUPON));

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/couponMember/repository/CouponMemberRepository.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/couponMember/repository/CouponMemberRepository.java
@@ -12,17 +12,17 @@ import com.nonsoolmate.exception.coupon.CouponException;
 
 public interface CouponMemberRepository
 		extends JpaRepository<CouponMember, Long>, CouponMemberCustomRepository {
-  
+
+	Optional<CouponMember> findByCouponIdAndMemberId(Long couponId, String memberId);
+
 	@Query(
-			"SELECT cm FROM CouponMember cm WHERE cm.couponMemberId = :couponMemberId AND cm.memberId = :memberId")
-	Optional<CouponMember> findCouponIdByCouponMemberIdAndMemberId(
+			"SELECT cm.couponId FROM CouponMember cm WHERE cm.couponMemberId = :couponMemberId AND cm.memberId = :memberId")
+	Optional<Long> findCouponIdByCouponMemberIdAndMemberId(
 			final Long couponMemberId, final String memberId);
 
-	default CouponMember findByCouponMemberIdAndMemberIdThrow(
+	default Long findByCouponMemberIdAndMemberIdThrow(
 			final Long couponMemberId, final String memberId) {
 		return findCouponIdByCouponMemberIdAndMemberId(couponMemberId, memberId)
 				.orElseThrow(() -> new CouponException(INVALID_COUPON));
 	}
-
-	Optional<CouponMember> findByCouponIdAndMemberId(Long couponId, String memberId);
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/couponMember/repository/CouponMemberRepository.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/couponMember/repository/CouponMemberRepository.java
@@ -16,11 +16,11 @@ public interface CouponMemberRepository
 	Optional<CouponMember> findByCouponIdAndMemberId(Long couponId, String memberId);
 
 	@Query(
-			"SELECT cm.couponId FROM CouponMember cm WHERE cm.couponMemberId = :couponMemberId AND cm.memberId = :memberId")
-	Optional<Long> findCouponIdByCouponMemberIdAndMemberId(
+			"SELECT cm FROM CouponMember cm WHERE cm.couponMemberId = :couponMemberId AND cm.memberId = :memberId")
+	Optional<CouponMember> findCouponIdByCouponMemberIdAndMemberId(
 			final Long couponMemberId, final String memberId);
 
-	default Long findByCouponMemberIdAndMemberIdThrow(
+	default CouponMember findByCouponMemberIdAndMemberIdThrow(
 			final Long couponMemberId, final String memberId) {
 		return findCouponIdByCouponMemberIdAndMemberId(couponMemberId, memberId)
 				.orElseThrow(() -> new CouponException(INVALID_COUPON));

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/couponMember/repository/CouponMemberRepository.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/couponMember/repository/CouponMemberRepository.java
@@ -1,12 +1,27 @@
 package com.nonsoolmate.couponMember.repository;
 
+import static com.nonsoolmate.exception.coupon.CouponExceptionType.*;
+
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.nonsoolmate.couponMember.entity.CouponMember;
+import com.nonsoolmate.exception.coupon.CouponException;
 
 public interface CouponMemberRepository
 		extends JpaRepository<CouponMember, Long>, CouponMemberCustomRepository {
 	Optional<CouponMember> findByCouponId(Long couponId);
+
+	@Query(
+			"SELECT cm.couponId FROM CouponMember cm WHERE cm.couponMemberId = :couponMemberId AND cm.memberId = :memberId")
+	Optional<Long> findCouponIdByCouponMemberIdAndMemberId(
+			final Long couponMemberId, final String memberId);
+
+	default Long findByCouponMemberIdAndMemberIdThrow(
+			final Long couponMemberId, final String memberId) {
+		return findCouponIdByCouponMemberIdAndMemberId(couponMemberId, memberId)
+				.orElseThrow(() -> new CouponException(INVALID_COUPON));
+	}
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/couponMember/repository/dto/CouponResponseDTO.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/couponMember/repository/dto/CouponResponseDTO.java
@@ -20,7 +20,7 @@ public class CouponResponseDTO {
 
 	private final CouponType couponType;
 
-	private final int discountRate;
+	private final double discountRate;
 
 	private final int discountAmount;
 
@@ -39,7 +39,7 @@ public class CouponResponseDTO {
 			String couponDescription,
 			String couponImageUrl,
 			CouponType couponType,
-			int discountRate,
+			double discountRate,
 			int discountAmount,
 			int ticketCount,
 			LocalDateTime validStartDate,

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/discount/entity/enums/DiscountType.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/discount/entity/enums/DiscountType.java
@@ -2,5 +2,5 @@ package com.nonsoolmate.discount.entity.enums;
 
 public enum DiscountType {
 	CONTINUOUS,
-	ONE_TIME
+	FIRST_PURCHASE
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/discountProduct/DiscountProductRepository.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/discountProduct/DiscountProductRepository.java
@@ -1,0 +1,15 @@
+package com.nonsoolmate.discountProduct;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.nonsoolmate.discountProduct.entity.DiscountProduct;
+import com.nonsoolmate.product.entity.Product;
+
+public interface DiscountProductRepository extends JpaRepository<DiscountProduct, Long> {
+	@Query("select dp from DiscountProduct dp where dp.product = :product")
+	List<DiscountProduct> findAllByProductId(@Param("product") final Product product);
+}

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/examRecord/entity/ExamRecord.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/examRecord/entity/ExamRecord.java
@@ -18,6 +18,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import com.nonsoolmate.common.BaseTimeEntity;
 import com.nonsoolmate.examRecord.entity.enums.EditingType;
 import com.nonsoolmate.examRecord.entity.enums.ExamResultStatus;
 import com.nonsoolmate.member.entity.Member;
@@ -32,7 +33,7 @@ import com.nonsoolmate.university.entity.Exam;
 					name = "UK_EXAM_MEMBER_EDITING_TYPE",
 					columnNames = {"exam_id", "member_id", "editing_type"})
 		})
-public class ExamRecord {
+public class ExamRecord extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long examRecordId;

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/matching/entity/Matching.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/matching/entity/Matching.java
@@ -7,13 +7,14 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import com.nonsoolmate.common.BaseTimeEntity;
 import com.nonsoolmate.member.entity.Member;
 import com.nonsoolmate.teacher.entity.Teacher;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Matching {
+public class Matching extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Member.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Member.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 
 import org.hibernate.validator.constraints.Length;
 
+import com.nonsoolmate.common.BaseTimeEntity;
 import com.nonsoolmate.exception.member.MemberException;
 import com.nonsoolmate.exception.member.MemberExceptionType;
 import com.nonsoolmate.member.entity.enums.PlatformType;
@@ -31,7 +32,7 @@ import io.hypersistence.utils.hibernate.id.Tsid;
 		})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseTimeEntity {
 	@Id @Tsid private String memberId;
 
 	@NotNull private String email;

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Membership.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Membership.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -37,4 +38,13 @@ public class Membership extends BaseTimeEntity {
 
 	@Enumerated(EnumType.STRING)
 	MembershipStatus status;
+
+	@Builder
+	private Membership(final Member member, final MembershipType membershipType) {
+		this.member = member;
+		this.membershipType = membershipType;
+		this.startDate = LocalDateTime.now();
+		this.endDate = LocalDateTime.now().plusDays(28);
+		this.status = MembershipStatus.IN_PROGRESS;
+	}
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Membership.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Membership.java
@@ -23,28 +23,30 @@ import com.nonsoolmate.member.entity.enums.MembershipType;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Membership extends BaseTimeEntity {
+	private static final int MEMBERSHIP_PERIOD = 27;
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	Long membershipId;
+	private Long membershipId;
 
-	@OneToOne Member member;
-
-	@Enumerated(EnumType.STRING)
-	MembershipType membershipType;
-
-	LocalDateTime startDate;
-
-	LocalDateTime endDate;
+	@OneToOne private Member member;
 
 	@Enumerated(EnumType.STRING)
-	MembershipStatus status;
+	private MembershipType membershipType;
+
+	private LocalDateTime startDate;
+
+	private LocalDateTime endDate;
+
+	@Enumerated(EnumType.STRING)
+	private MembershipStatus status;
 
 	@Builder
 	private Membership(final Member member, final MembershipType membershipType) {
 		this.member = member;
 		this.membershipType = membershipType;
 		this.startDate = LocalDateTime.now();
-		this.endDate = LocalDateTime.now().plusDays(28);
+		this.endDate = LocalDateTime.now().plusDays(MEMBERSHIP_PERIOD);
 		this.status = MembershipStatus.IN_PROGRESS;
 	}
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/entity/OrderDetail.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/entity/OrderDetail.java
@@ -39,7 +39,6 @@ public class OrderDetail extends BaseTimeEntity {
 	private Product product;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@NotNull
 	@JoinColumn(name = "coupon_member_id")
 	private CouponMember couponMember;
 

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/entity/OrderDetail.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/entity/OrderDetail.java
@@ -5,6 +5,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import lombok.AccessLevel;
@@ -12,13 +13,16 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import com.nonsoolmate.common.BaseTimeEntity;
 import com.nonsoolmate.member.entity.Member;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class OrderDetail {
-	@Id private String orderId;
+public class OrderDetail extends BaseTimeEntity {
+	@Id @Tsid private String orderId;
 
 	@NotNull private String orderName;
 
@@ -27,12 +31,11 @@ public class OrderDetail {
 	@JoinColumn(name = "customer_key")
 	private Member member;
 
-	@NotNull private long amount;
+	@Min(0)
+	private long amount;
 
 	@Builder
-	public OrderDetail(
-			final String orderId, final String orderName, final Member member, final long amount) {
-		this.orderId = orderId;
+	public OrderDetail(final String orderName, final Member member, final long amount) {
 		this.orderName = orderName;
 		this.member = member;
 		this.amount = amount;

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/entity/OrderDetail.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/entity/OrderDetail.java
@@ -14,7 +14,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import com.nonsoolmate.common.BaseTimeEntity;
+import com.nonsoolmate.couponMember.entity.CouponMember;
 import com.nonsoolmate.member.entity.Member;
+import com.nonsoolmate.product.entity.Product;
 
 import io.hypersistence.utils.hibernate.id.Tsid;
 
@@ -30,6 +32,16 @@ public class OrderDetail extends BaseTimeEntity {
 	@NotNull
 	@JoinColumn(name = "customer_key")
 	private Member member;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@NotNull
+	@JoinColumn(name = "product_id")
+	private Product product;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@NotNull
+	@JoinColumn(name = "coupon_member_id")
+	private CouponMember couponMember;
 
 	@Min(0)
 	private long amount;

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/entity/OrderDetail.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/entity/OrderDetail.java
@@ -47,9 +47,16 @@ public class OrderDetail extends BaseTimeEntity {
 	private long amount;
 
 	@Builder
-	public OrderDetail(final String orderName, final Member member, final long amount) {
+	private OrderDetail(
+			final String orderName,
+			final Member member,
+			final Product product,
+			final CouponMember couponMember,
+			final long amount) {
 		this.orderName = orderName;
 		this.member = member;
+		this.product = product;
+		this.couponMember = couponMember;
 		this.amount = amount;
 	}
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/repository/OrderRepository.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package com.nonsoolmate.order.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.nonsoolmate.order.entity.OrderDetail;
+
+public interface OrderRepository extends JpaRepository<OrderDetail, Long> {}

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/TransactionDetail.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/TransactionDetail.java
@@ -16,6 +16,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import com.nonsoolmate.common.BaseTimeEntity;
 import com.nonsoolmate.order.entity.OrderDetail;
 
 @Entity
@@ -27,7 +28,7 @@ import com.nonsoolmate.order.entity.OrderDetail;
 		})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class TransactionDetail {
+public class TransactionDetail extends BaseTimeEntity {
 	@Id private String transactionKey;
 
 	@NotNull private String paymentKey;

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/TransactionDetail.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/TransactionDetail.java
@@ -47,11 +47,13 @@ public class TransactionDetail extends BaseTimeEntity {
 	public TransactionDetail(
 			final String transactionKey,
 			final String paymentKey,
+			final String customerKey,
 			final OrderDetail order,
 			final String receiptUrl,
 			final LocalDateTime transactionAt) {
 		this.transactionKey = transactionKey;
 		this.paymentKey = paymentKey;
+		this.customerKey = customerKey;
 		this.order = order;
 		this.receiptUrl = receiptUrl;
 		this.transactionAt = transactionAt;

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/TransactionDetail.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/TransactionDetail.java
@@ -23,7 +23,7 @@ import com.nonsoolmate.order.entity.OrderDetail;
 @Table(
 		uniqueConstraints = {
 			@UniqueConstraint(
-					name = "UK_TRANSACTION_KEY_CUSTOMER_KEY_KEY",
+					name = "UK_TRANSACTION_KEY_ORDER_ID",
 					columnNames = {"transactionKey", "order_id"})
 		})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -44,7 +44,7 @@ public class TransactionDetail extends BaseTimeEntity {
 	@NotNull LocalDateTime transactionAt;
 
 	@Builder
-	public TransactionDetail(
+	private TransactionDetail(
 			final String transactionKey,
 			final String paymentKey,
 			final String customerKey,

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/TransactionDetail.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/entity/TransactionDetail.java
@@ -33,6 +33,8 @@ public class TransactionDetail extends BaseTimeEntity {
 
 	@NotNull private String paymentKey;
 
+	@NotNull private String customerKey;
+
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "order_id")
 	private OrderDetail order;

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/repository/TransactionDetailRepository.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/payment/repository/TransactionDetailRepository.java
@@ -1,0 +1,9 @@
+package com.nonsoolmate.payment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.nonsoolmate.payment.entity.TransactionDetail;
+
+public interface TransactionDetailRepository extends JpaRepository<TransactionDetail, String> {
+	boolean existsByCustomerKey(final String customerKey);
+}

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/product/entity/Product.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/product/entity/Product.java
@@ -1,5 +1,6 @@
 package com.nonsoolmate.product.entity;
 
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
@@ -28,6 +29,10 @@ public class Product {
 	private long price;
 
 	@NotNull private String description;
+
+	@NotNull private LocalDateTime startDate;
+
+	private LocalDateTime endDate;
 
 	public List<String> getDescriptions() {
 		return Arrays.asList(description.split(","));

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/product/repository/ProductRepository.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/product/repository/ProductRepository.java
@@ -1,0 +1,18 @@
+package com.nonsoolmate.product.repository;
+
+import static com.nonsoolmate.exception.product.ProductExceptionType.*;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.nonsoolmate.exception.product.ProductException;
+import com.nonsoolmate.product.entity.Product;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+	Optional<Product> findByProductId(Long productId);
+
+	default Product findByProductIdOrThrow(Long productId) {
+		return findByProductId(productId).orElseThrow(() -> new ProductException(INVALID_PRODUCT_ID));
+	}
+}

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/TossPaymentService.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/TossPaymentService.java
@@ -14,9 +14,9 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 
 import com.nonsoolmate.exception.common.BusinessException;
 import com.nonsoolmate.exception.payment.BillingException;
-import com.nonsoolmate.toss.service.dto.request.IssueBillingDTO;
+import com.nonsoolmate.toss.service.dto.request.IssueBillingKeyDTO;
 import com.nonsoolmate.toss.service.dto.response.TossPaymentBillingDTO;
-import com.nonsoolmate.toss.service.vo.TossPaymentBillingVO;
+import com.nonsoolmate.toss.service.vo.TossPaymentBillingKeyVO;
 
 import reactor.core.publisher.Mono;
 
@@ -36,18 +36,18 @@ public class TossPaymentService {
 		return Base64.getEncoder().encodeToString(apiKey.getBytes(StandardCharsets.UTF_8));
 	}
 
-	public TossPaymentBillingVO issueBilling(final String customerKey, final String authKey) {
-		IssueBillingDTO issueBillingDTO = IssueBillingDTO.of(authKey, customerKey);
-		TossPaymentBillingDTO tossPaymentBillingDTO = getTossPaymentBillingDTO(issueBillingDTO);
+	public TossPaymentBillingKeyVO issueBillingKey(final String customerKey, final String authKey) {
+		IssueBillingKeyDTO issueBillingKeyDTO = IssueBillingKeyDTO.of(authKey, customerKey);
+		TossPaymentBillingDTO tossPaymentBillingDTO = getTossPaymentBillingKeyDTO(issueBillingKeyDTO);
 
-		return TossPaymentBillingVO.of(
+		return TossPaymentBillingKeyVO.of(
 				tossPaymentBillingDTO.customerKey(),
 				tossPaymentBillingDTO.billingKey(),
 				tossPaymentBillingDTO.cardCompany(),
 				tossPaymentBillingDTO.cardNumber());
 	}
 
-	private TossPaymentBillingDTO getTossPaymentBillingDTO(IssueBillingDTO request) {
+	private TossPaymentBillingDTO getTossPaymentBillingKeyDTO(IssueBillingKeyDTO request) {
 		WebClient webClient = WebClient.builder().build();
 		try {
 			return webClient
@@ -55,7 +55,7 @@ public class TossPaymentService {
 					.uri(TOSS_ISSUE_BILLING_URI)
 					.header(TOSS_AUTHORIZATION_HEADER, TOSS_AUTHORIZATION_PREFIX + secretKey)
 					.header("Content-Type", "application/json")
-					.body(Mono.just(request), IssueBillingDTO.class)
+					.body(Mono.just(request), IssueBillingKeyDTO.class)
 					.retrieve()
 					.bodyToMono(TossPaymentBillingDTO.class)
 					.block();

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/dto/request/IssueBillingDTO.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/dto/request/IssueBillingDTO.java
@@ -1,7 +1,0 @@
-package com.nonsoolmate.toss.service.dto.request;
-
-public record IssueBillingDTO(String authKey, String customerKey) {
-	public static IssueBillingDTO of(final String authKey, final String customerKey) {
-		return new IssueBillingDTO(authKey, customerKey);
-	}
-}

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/dto/request/IssueBillingKeyDTO.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/dto/request/IssueBillingKeyDTO.java
@@ -1,0 +1,7 @@
+package com.nonsoolmate.toss.service.dto.request;
+
+public record IssueBillingKeyDTO(String authKey, String customerKey) {
+	public static IssueBillingKeyDTO of(final String authKey, final String customerKey) {
+		return new IssueBillingKeyDTO(authKey, customerKey);
+	}
+}

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/dto/request/RequestBillingDTO.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/dto/request/RequestBillingDTO.java
@@ -1,0 +1,8 @@
+package com.nonsoolmate.toss.service.dto.request;
+
+public record RequestBillingDTO(String customerKey, long amount, String orderId, String orderName) {
+	public static RequestBillingDTO of(
+			final String customerKey, final long amount, final String orderId, final String orderName) {
+		return new RequestBillingDTO(customerKey, amount, orderId, orderName);
+	}
+}

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/dto/response/TossPaymentTransactionDTO.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/dto/response/TossPaymentTransactionDTO.java
@@ -1,0 +1,6 @@
+package com.nonsoolmate.toss.service.dto.response;
+
+public record TossPaymentTransactionDTO(
+		String paymentKey, String approvedAt, Receipt receipt, String transactionKey) {
+	public record Receipt(String url) {}
+}

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/dto/response/TossPaymentTransactionDTO.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/dto/response/TossPaymentTransactionDTO.java
@@ -1,6 +1,6 @@
 package com.nonsoolmate.toss.service.dto.response;
 
 public record TossPaymentTransactionDTO(
-		String paymentKey, String approvedAt, Receipt receipt, String transactionKey) {
+		String lastTransactionKey, String paymentKey, String approvedAt, Receipt receipt) {
 	public record Receipt(String url) {}
 }

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/vo/TossPaymentBillingKeyVO.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/vo/TossPaymentBillingKeyVO.java
@@ -1,12 +1,12 @@
 package com.nonsoolmate.toss.service.vo;
 
-public record TossPaymentBillingVO(
+public record TossPaymentBillingKeyVO(
 		String customerKey, String billingKey, String cardCompany, String cardNumber) {
-	public static TossPaymentBillingVO of(
+	public static TossPaymentBillingKeyVO of(
 			final String customerKey,
 			final String billingKey,
 			final String cardCompany,
 			final String cardNumber) {
-		return new TossPaymentBillingVO(customerKey, billingKey, cardCompany, cardNumber);
+		return new TossPaymentBillingKeyVO(customerKey, billingKey, cardCompany, cardNumber);
 	}
 }

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/vo/TossPaymentTransactionVO.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/vo/TossPaymentTransactionVO.java
@@ -6,12 +6,12 @@ import java.time.format.DateTimeFormatter;
 import com.nonsoolmate.toss.service.dto.response.TossPaymentTransactionDTO;
 
 public record TossPaymentTransactionVO(
-		String paymentKey, LocalDateTime transactionAt, String receiptUrl, String transactionKey) {
+		String transactionKey, String paymentKey, LocalDateTime transactionAt, String receiptUrl) {
 	public static TossPaymentTransactionVO fromDTO(TossPaymentTransactionDTO dto) {
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
 		LocalDateTime transformedTransactionAt =
 				LocalDateTime.parse(dto.approvedAt().substring(0, 19), formatter);
 		return new TossPaymentTransactionVO(
-				dto.paymentKey(), transformedTransactionAt, dto.receipt().url(), dto.transactionKey());
+				dto.lastTransactionKey(), dto.paymentKey(), transformedTransactionAt, dto.receipt().url());
 	}
 }

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/vo/TossPaymentTransactionVO.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/toss/service/vo/TossPaymentTransactionVO.java
@@ -1,0 +1,17 @@
+package com.nonsoolmate.toss.service.vo;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.nonsoolmate.toss.service.dto.response.TossPaymentTransactionDTO;
+
+public record TossPaymentTransactionVO(
+		String paymentKey, LocalDateTime transactionAt, String receiptUrl, String transactionKey) {
+	public static TossPaymentTransactionVO fromDTO(TossPaymentTransactionDTO dto) {
+		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+		LocalDateTime transformedTransactionAt =
+				LocalDateTime.parse(dto.approvedAt().substring(0, 19), formatter);
+		return new TossPaymentTransactionVO(
+				dto.paymentKey(), transformedTransactionAt, dto.receipt().url(), dto.transactionKey());
+	}
+}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#156 -> dev
- closed #156 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- Transaction에 customerKey를 추가했습니다
  - Order를 통해 조회하는 오버헤드를 줄이기 위해 추가했고, customerKey를 이용하여 이전 결제 내역 조회 또는 첫 결제인지 확인하는 정도로 사용될 것 같아 연관관계 매핑 없이 사용해도 괜찮다는 생각이 들었습니다
- Order
  - 주문에 대한 정보인데, 이에 대해 어떤 상품을 구매하는지에 대해 추적하지 않고 있는 것이 모순이라는 생각이 들었습니다 이에 따라 Product를 포함하도록 변경했습니다
  - CouponMember -> 사용자가 어떤 쿠폰을 적용하였는지에 대해 서버에서 알 수 있는 방법이 없기 때문에 CouponMember를 추가하였습니다
- Coupon과 Discount의 할인율에 대한 정보를 저장하는 타입이 달라 이를 double로 통일하였습니다
- BaseEntity 적용 안된 엔티티가 좀 있는 것 같아 제 판단에 필요하다고 생각하는 엔티티들에 추가했습니다
- 코드를 읽어보시고 이해 안가시는 부분이 있다면(변수명, 함수명 등) 리뷰 부탁드립니다
- 토스페이먼츠에 문의 결과 transactionKey는 사라진 필드이며 각 거래(주문에서의 구매, 취소 등을 구분)의 구분은 lastTransactionKey로 하면 된다는 답변을 받아 이를 수정하였습니다!
- 또한 membership 업데이트와 관련하여 현재 membership 테이블에는 반영이 되지만, 첨삭권 개수는 반영이 되지 않는데요 그 이유는 다음과 같습니다
  - 1. PR의 크기가 현재로서도 너무 크다
  - 2. membership 상품에 대한 정보 변경에 대한 논의가 이루어지지 않음
    - ex. 10월까지 BASIC 플랜의 내용이 첨삭권 2개 제공, 재첨삭권 1개 제공이었음 -> 11월부터 변경된 BASIC 플랜이 생긴다면 새로운 Product로 결제가 되어야  하는지 기존의 내용으로 결제가 되어야하는지에 대한 논의가 되지 않음
- 따라서 첨삭권 변경 부분은 논의후에 따로 PR을 날리고 테스트 코드도 따로 작성하겠습니다!

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="1387" alt="image" src="https://github.com/user-attachments/assets/46ce8682-eeed-4748-a61c-2913698da628">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
