### PR TITLE
[FEAT] Product 엔티티 변경

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/service/MembershipService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/service/MembershipService.java
@@ -20,9 +20,6 @@ public class MembershipService {
 	private final MemberRepository memberRepository;
 	private final MembershipRepository membershipRepository;
 
-	private final String BASIC_MEMBERSHIP_TYPE_NAME = "베이직 플랜";
-	private final String PREMIUM_MEMBERSHIP_TYPE_NAME = "프리미엄 플랜";
-
 	public MembershipAndTicketResponseDTO getMembershipAndTicket(final String memberId) {
 		Member member = memberRepository.findByMemberIdOrThrow(memberId);
 		MembershipType membershipType = getMembershipType(member);
@@ -47,20 +44,9 @@ public class MembershipService {
 
 	public Membership createMembership(final String memberId, final Product product) {
 		Member member = memberRepository.findByMemberIdOrThrow(memberId);
-		MembershipType membershipType = getMembershipTypeByProduct(product);
+		MembershipType membershipType = MembershipType.getMembershipType(product.getProductName());
 		Membership membership =
 				Membership.builder().member(member).membershipType(membershipType).build();
 		return membershipRepository.save(membership);
-	}
-
-	private MembershipType getMembershipTypeByProduct(final Product product) {
-		switch (product.getProductName()) {
-			case BASIC_MEMBERSHIP_TYPE_NAME:
-				return MembershipType.BASIC;
-			case PREMIUM_MEMBERSHIP_TYPE_NAME:
-				return MembershipType.PREMIUM;
-			default:
-				return MembershipType.NONE;
-		}
 	}
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/order/service/OrderService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/order/service/OrderService.java
@@ -14,7 +14,6 @@ import com.nonsoolmate.member.repository.MemberRepository;
 import com.nonsoolmate.order.entity.OrderDetail;
 import com.nonsoolmate.order.repository.OrderRepository;
 import com.nonsoolmate.product.entity.Product;
-import com.nonsoolmate.product.repository.ProductRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -22,24 +21,22 @@ import com.nonsoolmate.product.repository.ProductRepository;
 public class OrderService {
 	private final OrderRepository orderRepository;
 	private final MemberRepository memberRepository;
-	private final ProductRepository productRepository;
 	private final DiscountProductService discountProductService;
 	private final CouponMemberService couponMemberService;
 
 	@Transactional
 	public OrderDetail createOrder(
-			final Long productId, final Long couponMemberId, final String memberId) {
+			final Product product, final Long couponMemberId, final String memberId) {
 		boolean isCouponApplied = couponMemberId != null;
 		if (isCouponApplied) {
-			return createOrderWithCoupon(productId, couponMemberId, memberId);
+			return createOrderWithCoupon(product, couponMemberId, memberId);
 		} else {
-			return createOrderWithoutCoupon(productId, memberId);
+			return createOrderWithoutCoupon(product, memberId);
 		}
 	}
 
-	private OrderDetail createOrderWithoutCoupon(final Long productId, final String memberId) {
+	private OrderDetail createOrderWithoutCoupon(final Product product, final String memberId) {
 		Member member = memberRepository.findByMemberIdOrThrow(memberId);
-		Product product = productRepository.findByProductIdOrThrow(productId);
 		long discountedProductPrice =
 				discountProductService.getDiscountedProductPrice(product.getProductId(), memberId);
 
@@ -55,10 +52,9 @@ public class OrderService {
 	}
 
 	private OrderDetail createOrderWithCoupon(
-			final Long productId, final Long couponMemberId, final String memberId) {
+			final Product product, final Long couponMemberId, final String memberId) {
 		Member member = memberRepository.findByMemberIdOrThrow(memberId);
 		CouponMember validCouponMember = couponMemberService.validateCoupon(couponMemberId, memberId);
-		Product product = productRepository.findByProductIdOrThrow(productId);
 		long discountedProductPrice =
 				discountProductService.getDiscountedProductPrice(product.getProductId(), memberId);
 		Coupon validCoupon = couponMemberService.getCoupon(validCouponMember.getCouponId());

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/member/MembershipExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/member/MembershipExceptionType.java
@@ -1,0 +1,26 @@
+package com.nonsoolmate.exception.member;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.HttpStatus;
+
+import com.nonsoolmate.exception.common.ExceptionType;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum MembershipExceptionType implements ExceptionType {
+	NOT_FOUND_MEMBERSHIP_TYPE(HttpStatus.NOT_FOUND, "존재하지 않는 멤버십 타입입니다.");
+
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public HttpStatus status() {
+		return this.status;
+	}
+
+	@Override
+	public String message() {
+		return this.message;
+	}
+}

--- a/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/payment/PaymentExceptionType.java
+++ b/nonsoolmate-common/src/main/java/com/nonsoolmate/exception/payment/PaymentExceptionType.java
@@ -9,7 +9,9 @@ import com.nonsoolmate.exception.common.ExceptionType;
 
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum PaymentExceptionType implements ExceptionType {
-	ALREADY_MEMBERSHIP_BILLING(HttpStatus.BAD_REQUEST, "이미 멤버십 결제가 진행중입니다");
+	ALREADY_MEMBERSHIP_BILLING(HttpStatus.BAD_REQUEST, "이미 멤버십 결제가 진행중입니다"),
+	NOT_SUBSCRIPTION_PRODUCT(HttpStatus.BAD_REQUEST, "해당 상품은 멤버십 상품이 아닙니다"),
+	;
 	;
 
 	private final HttpStatus status;

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/enums/MembershipType.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/enums/MembershipType.java
@@ -1,7 +1,26 @@
 package com.nonsoolmate.member.entity.enums;
 
+import static com.nonsoolmate.exception.member.MemberExceptionType.*;
+import static com.nonsoolmate.exception.member.MembershipExceptionType.*;
+
+import java.util.Arrays;
+
+import lombok.RequiredArgsConstructor;
+
+import com.nonsoolmate.exception.common.BusinessException;
+
+@RequiredArgsConstructor
 public enum MembershipType {
-	NONE,
-	BASIC,
-	PREMIUM;
+	NONE("멤버십 없음"),
+	BASIC("베이직 플랜"),
+	PREMIUM("프리미엄 플랜");
+
+	private final String description;
+
+	public static MembershipType getMembershipType(String description) {
+		return Arrays.stream(MembershipType.values())
+				.filter(type -> type.description.equals(description))
+				.findFirst()
+				.orElseThrow(() -> new BusinessException(NOT_FOUND_MEMBERSHIP_TYPE));
+	}
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/product/entity/Product.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/product/entity/Product.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -15,6 +17,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import com.nonsoolmate.product.entity.enums.ProductType;
+
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -24,6 +28,16 @@ public class Product {
 	private Long productId;
 
 	@NotNull private String productName;
+
+	@Enumerated(EnumType.STRING)
+	@NotNull
+	private ProductType productType;
+
+	@Min(0)
+	private long reviewTicketCount;
+
+	@Min(0)
+	private long reReviewTicketCount;
 
 	@Min(0)
 	private long price;

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/product/entity/enums/ProductType.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/product/entity/enums/ProductType.java
@@ -1,0 +1,6 @@
+package com.nonsoolmate.product.entity.enums;
+
+public enum ProductType {
+	SUBSCRIPTION,
+	TICKET
+}


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#175 -> dev
- closed #175 


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 저희 서비스의 종류가 첨삭, 재첨삭권이 포함되는 개념이라고 생각하여 기존 엔티티에 필드를 추가합니다
  - review_ticket_count, re_review_ticket_count
  - 상품 유형을 구분합니다(ProductType)
- 구독형 결제에 상품이 구독형 상품인지 검증하는 로직을 추가했습니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- X

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- MembershipType에서 description을 만들어 BASIC("베이직 플랜") 등으로 관리하여 상품 이름과 멤버십 타입을 매칭시켜 찾는 방식을 도입하는 것에 대해 궁금합니다!
- 현재 Membership 서비스에서는 static final 변수 선언을 통해 MembershipType enum을 찾고 있는데 좋은 방식 같지는 않아서요!
