### PR TITLE
[FEAT] 멤버십 구매 이후 첨삭권 개수 반영 로직 구현

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/PaymentService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/PaymentService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.nonsoolmate.exception.payment.PaymentException;
 import com.nonsoolmate.member.entity.Member;
+import com.nonsoolmate.member.entity.Membership;
 import com.nonsoolmate.member.service.MembershipService;
 import com.nonsoolmate.order.entity.OrderDetail;
 import com.nonsoolmate.order.service.OrderService;
@@ -62,7 +63,8 @@ public class PaymentService {
 
 		TransactionDetail transaction = transactionService.createTransaction(transactionVO);
 
-		Member member = membershipService.createMembership(memberId, order.getProduct()).getMember();
+		Membership membership = membershipService.createMembership(memberId, product);
+		Member member = membership.getMember();
 		member.updateTicketCount(
 				order.getProduct().getReviewTicketCount(), order.getProduct().getReReviewTicketCount());
 

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/PaymentService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/PaymentService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.nonsoolmate.exception.payment.PaymentException;
+import com.nonsoolmate.member.entity.Member;
 import com.nonsoolmate.member.service.MembershipService;
 import com.nonsoolmate.order.entity.OrderDetail;
 import com.nonsoolmate.order.service.OrderService;
@@ -61,9 +62,9 @@ public class PaymentService {
 
 		TransactionDetail transaction = transactionService.createTransaction(transactionVO);
 
-		membershipService.createMembership(memberId, order.getProduct());
-		// TODO: update member review ticket count
-		// here
+		Member member = membershipService.createMembership(memberId, order.getProduct()).getMember();
+		member.updateTicketCount(
+				order.getProduct().getReviewTicketCount(), order.getProduct().getReReviewTicketCount());
 
 		// create next month order
 		orderService.createOrder(product, NO_COUPON_MEMBER_ID, memberId);

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Member.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Member.java
@@ -97,6 +97,11 @@ public class Member extends BaseTimeEntity {
 		this.reReviewTicketCount -= 1;
 	}
 
+	public void updateTicketCount(int reviewTicketCount, int reReviewTicketCount) {
+		this.reviewTicketCount += reviewTicketCount;
+		this.reReviewTicketCount += reReviewTicketCount;
+	}
+
 	public void updateMemberProfile(
 			String name, String gender, String birthYear, String email, String phoneNumber) {
 		this.email = email;

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/product/entity/Product.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/product/entity/Product.java
@@ -34,10 +34,10 @@ public class Product {
 	private ProductType productType;
 
 	@Min(0)
-	private long reviewTicketCount;
+	private int reviewTicketCount;
 
 	@Min(0)
-	private long reReviewTicketCount;
+	private int reReviewTicketCount;
 
 	@Min(0)
 	private long price;


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#170 -> dev
- closed #170

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 멤버십 구매 이후 첨삭권이 반영되는 로직을 구현했습니다
- 멤버십 반영 결과에서 3번째를 보시면 11개로 되어있는데, 해당 상품 구매시 첨삭권 1개, 재첨삭권 1개로 더미데이터가 세팅되어있었고, 회원에게 기존에 첨삭권 및 재첨삭권 각각 10개가 존재했습니다 이에 상품 구매 이후 11개로 변경된 모습입니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 결제 완료 화면
<img width="838" alt="image" src="https://github.com/user-attachments/assets/7801285d-f71a-405e-bd1a-431c9f963fb8">

- 멤버십 반영 결과
<img width="301" alt="스크린샷 2024-10-07 오후 2 42 02" src="https://github.com/user-attachments/assets/9f4bb342-24dc-4a94-bdc5-f5fcbcf19b88">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
