### PR TITLE
[FEAT] 상품 리스트 조회 API 구현

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/discountProduct/service/DiscountProductService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/discountProduct/service/DiscountProductService.java
@@ -26,7 +26,7 @@ public class DiscountProductService {
 		Product product = productRepository.findByProductIdOrThrow(productId);
 		double discountedPrice = product.getPrice();
 		List<DiscountProduct> defaultDiscountProducts =
-				getDefaultDiscountProductsByProduct(product, memberId);
+				getDiscountProductsByProductAndMemberId(product, memberId);
 
 		for (DiscountProduct discountProduct : defaultDiscountProducts) {
 			Discount discount = discountProduct.getDiscount();
@@ -36,12 +36,16 @@ public class DiscountProductService {
 		return Math.round(discountedPrice);
 	}
 
-	public List<DiscountProduct> getDefaultDiscountProductsByProduct(
+	public List<DiscountProduct> getDiscountProductsByProductAndMemberId(
 			final Product product, final String memberId) {
 		boolean isFirstPurchaseMember = transactionService.isFirstPurchase(memberId);
 		if (isFirstPurchaseMember) {
-			return discountProductRepository.findAllByProductId(product);
+			return getDefaultDiscountProductsByProduct(product);
 		}
 		return discountProductRepository.findAllByProductIdAndDiscountIsContinuous(product);
+	}
+
+	public List<DiscountProduct> getDefaultDiscountProductsByProduct(final Product product) {
+		return discountProductRepository.findAllByProduct(product);
 	}
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/global/config/SecurityConfig.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/global/config/SecurityConfig.java
@@ -27,7 +27,7 @@ import io.swagger.v3.oas.models.PathItem.HttpMethod;
 public class SecurityConfig {
 
 	public static final String[] AUTH_WHITELIST = {
-		"/", "/error", "/favicon.ico", "/actuator/health", "/check/profile"
+		"/", "/error", "/favicon.ico", "/actuator/health", "/check/profile", "/products"
 	};
 
 	public static final String[] AUTH_WHITELIST_WILDCARD = {

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/product/controller/ProductApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/product/controller/ProductApi.java
@@ -1,5 +1,7 @@
 package com.nonsoolmate.product.controller;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 
 import com.nonsoolmate.product.controller.dto.ProductResponseDTO;
@@ -20,4 +22,8 @@ public interface ProductApi {
 	@Operation(summary = "결제 페이지: 상품 단일 조회(가격, 할인 정보)", description = "상품 단일 정보에 대해 조회하는 경우")
 	ResponseEntity<ProductResponseDTO> getProduct(
 			@Schema(description = "상품 id") Long productId, @Schema(hidden = true) String memberId);
+
+	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "상품 리스트 조회에 성공했습니다.")})
+	@Operation(summary = "멤버십 페이지: 상품 리스트 조회", description = "상품 리스트를 조회하는 경우")
+	ResponseEntity<List<ProductResponseDTO>> getProducts();
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/product/controller/ProductController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/product/controller/ProductController.java
@@ -1,5 +1,7 @@
 package com.nonsoolmate.product.controller;
 
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
@@ -22,6 +24,12 @@ public class ProductController implements ProductApi {
 	public ResponseEntity<ProductResponseDTO> getProduct(
 			@PathVariable("productId") final Long productId, @AuthMember final String memberId) {
 		ProductResponseDTO response = productService.getProduct(productId, memberId);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("")
+	public ResponseEntity<List<ProductResponseDTO>> getProducts() {
+		List<ProductResponseDTO> response = productService.getProducts();
 		return ResponseEntity.ok(response);
 	}
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/product/controller/dto/ProductResponseDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/product/controller/dto/ProductResponseDTO.java
@@ -10,13 +10,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record ProductResponseDTO(
 		@Schema(description = "상품 id", example = "1") long productId,
 		@Schema(description = "상품 이름", example = "베이직 플랜") String productName,
+		@Schema(description = "상품 설명", example = "상품 설명 리스트") List<String> productDescriptions,
 		@Schema(description = "상품 원가", example = "100000") long price,
 		@Schema(description = "상품 기본 할인 정보") List<DiscountResponseDTO> defaultDiscounts) {
 	public static ProductResponseDTO of(
 			final Long productId,
 			final String productName,
+			final List<String> productDescriptions,
 			final long price,
 			final List<DiscountResponseDTO> defaultDiscounts) {
-		return new ProductResponseDTO(productId, productName, price, defaultDiscounts);
+		return new ProductResponseDTO(
+				productId, productName, productDescriptions, price, defaultDiscounts);
 	}
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/product/service/ProductService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/product/service/ProductService.java
@@ -19,22 +19,49 @@ import com.nonsoolmate.product.repository.ProductRepository;
 @Transactional(readOnly = true)
 public class ProductService {
 	private final ProductRepository productRepository;
-	private final DiscountProductService productProductService;
+	private final DiscountProductService discountProductService;
 
 	public ProductResponseDTO getProduct(final Long productId, final String memberId) {
 		Product product = productRepository.findByProductIdOrThrow(productId);
-		List<DiscountProduct> defaultDiscountProducts =
-				productProductService.getDefaultDiscountProductsByProduct(product, memberId);
-		List<DiscountResponseDTO> defaultDiscounts =
-				defaultDiscountProducts.stream()
-						.map(
-								discountProduct ->
-										DiscountResponseDTO.of(
-												discountProduct.getDiscount().getDiscountId(),
-												discountProduct.getDiscount().getDiscountName(),
-												discountProduct.getDiscount().getDiscountRate()))
-						.toList();
+		List<DiscountProduct> discountProducts =
+				discountProductService.getDiscountProductsByProductAndMemberId(product, memberId);
+		List<DiscountResponseDTO> discountResponseDTOs =
+				convertToDiscountResponseDTOs(discountProducts);
 		return ProductResponseDTO.of(
-				product.getProductId(), product.getProductName(), product.getPrice(), defaultDiscounts);
+				product.getProductId(),
+				product.getProductName(),
+				product.getDescriptions(),
+				product.getPrice(),
+				discountResponseDTOs);
+	}
+
+	public List<ProductResponseDTO> getProducts() {
+		List<Product> products = productRepository.findProductsByAvailable();
+		return products.stream().map(this::createProductResponseDTO).toList();
+	}
+
+	private ProductResponseDTO createProductResponseDTO(Product product) {
+		List<DiscountProduct> discountProducts =
+				discountProductService.getDefaultDiscountProductsByProduct(product);
+		List<DiscountResponseDTO> discountResponseDTOs =
+				convertToDiscountResponseDTOs(discountProducts);
+		return ProductResponseDTO.of(
+				product.getProductId(),
+				product.getProductName(),
+				product.getDescriptions(),
+				product.getPrice(),
+				discountResponseDTOs);
+	}
+
+	private List<DiscountResponseDTO> convertToDiscountResponseDTOs(
+			List<DiscountProduct> discountProducts) {
+		return discountProducts.stream()
+				.map(
+						discountProduct ->
+								DiscountResponseDTO.of(
+										discountProduct.getDiscount().getDiscountId(),
+										discountProduct.getDiscount().getDiscountName(),
+										discountProduct.getDiscount().getDiscountRate()))
+				.toList();
 	}
 }

--- a/nonsoolmate-batch/src/main/java/com/nonsoolmate/payment/BillingPaymentService.java
+++ b/nonsoolmate-batch/src/main/java/com/nonsoolmate/payment/BillingPaymentService.java
@@ -98,7 +98,7 @@ public class BillingPaymentService {
 		Product product = productRepository.findByProductIdOrThrow(productId);
 		double discountedPrice = product.getPrice();
 
-		List<DiscountProduct> discountProducts = discountProductRepository.findAllByProductId(product);
+		List<DiscountProduct> discountProducts = discountProductRepository.findAllByProduct(product);
 		boolean isFirstPurchaseMember = isFirstPurchase(memberId);
 
 		for (DiscountProduct discountProduct : discountProducts) {

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/discountProduct/entity/DiscountProduct.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/discountProduct/entity/DiscountProduct.java
@@ -35,5 +35,5 @@ public class DiscountProduct {
 	private Discount discount;
 
 	@NotNull LocalDateTime startDate;
-	LocalDateTime endDate;
+	@NotNull LocalDateTime endDate;
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/discountProduct/repository/DiscountProductRepository.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/discountProduct/repository/DiscountProductRepository.java
@@ -12,5 +12,5 @@ import com.nonsoolmate.product.entity.Product;
 public interface DiscountProductRepository
 		extends JpaRepository<DiscountProduct, Long>, DiscountProductCustomRepository {
 	@Query("select dp from DiscountProduct dp where dp.product = :product")
-	List<DiscountProduct> findAllByProductId(@Param("product") final Product product);
+	List<DiscountProduct> findAllByProduct(@Param("product") final Product product);
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/product/entity/Product.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/product/entity/Product.java
@@ -46,7 +46,7 @@ public class Product {
 
 	@NotNull private LocalDateTime startDate;
 
-	private LocalDateTime endDate;
+	@NotNull private LocalDateTime endDate;
 
 	public List<String> getDescriptions() {
 		return Arrays.asList(description.split(","));

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/product/repository/ProductRepository.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/product/repository/ProductRepository.java
@@ -2,9 +2,11 @@ package com.nonsoolmate.product.repository;
 
 import static com.nonsoolmate.exception.product.ProductExceptionType.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import com.nonsoolmate.exception.product.ProductException;
 import com.nonsoolmate.product.entity.Product;
@@ -15,4 +17,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 	default Product findByProductIdOrThrow(Long productId) {
 		return findByProductId(productId).orElseThrow(() -> new ProductException(INVALID_PRODUCT_ID));
 	}
+
+	@Query(
+			"select p from Product p where p.startDate <= current_timestamp and p.endDate >= current_timestamp")
+	List<Product> findProductsByAvailable();
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#181 -> dev
- closed #181

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 상품 리스트 조회 API를 구현했습니다
- ProductResponseDTO에 상품 설명이 누락되어 필드를 추가했습니다
- Product와 DiscountProduct의 endDate가 빈 값일 수 있다고 생각해 처음에 not null 제약조건을 넣지 않았는데, 현재 판매하고 있는 + 적용되고 있는 할인 정보를 가져올 때 null이면 문제가 생길 것 같아 판매 기간이 정해지지 않더라도 임시로 값을 넣어둘 수 있도록 제약조건을 추가했습니다
- 위의 변경사항에 따라 할인 정보를 가져올 때 startDate와 endDate를 고려하는 로직은 따로 PR 날리겠습니다!
- 중복되는 로직을 리팩터링하는 과정을 함께 포함했습니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
![스크린샷 2024-10-09 오후 4 38 08](https://github.com/user-attachments/assets/8e235b1e-2cbf-450a-b9b0-b24232b19a55)


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
