### PR TITLE
[FEAT] 다음 달 결제 정보 조회 API

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MembershipApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MembershipApi.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 
 import com.nonsoolmate.global.security.AuthMember;
 import com.nonsoolmate.member.controller.dto.response.MembershipAndTicketResponseDTO;
+import com.nonsoolmate.member.controller.dto.response.PaymentInfoResponseDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -16,5 +17,10 @@ public interface MembershipApi {
 	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "내 멤버십과 첨삭권 개수를 조회합니다")})
 	@Operation(summary = "모달: 내 멤버십과 첨삭권 개수 확인", description = "이름, 멤버십, 첨삭권 개수를 조회합니다")
 	ResponseEntity<MembershipAndTicketResponseDTO> getMembershipAndTicket(
+			@Parameter(hidden = true) @AuthMember String memberId);
+
+	@ApiResponses(value = {@ApiResponse(responseCode = "200", description = "다음달 결제 정보를 조회합니다.")})
+	@Operation(summary = "다음달 결제 정보", description = "다음달 결제 정보를 조회합니다.")
+	ResponseEntity<PaymentInfoResponseDTO> getNextPaymentInfo(
 			@Parameter(hidden = true) @AuthMember String memberId);
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MembershipController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MembershipController.java
@@ -1,7 +1,10 @@
 package com.nonsoolmate.member.controller;
 
+import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.nonsoolmate.global.security.AuthMember;
 import com.nonsoolmate.member.controller.dto.response.MembershipAndTicketResponseDTO;
+import com.nonsoolmate.member.controller.dto.response.PaymentInfoResponseDTO;
 import com.nonsoolmate.member.service.MembershipService;
 
 @RestController
@@ -23,5 +27,19 @@ public class MembershipController implements MembershipApi {
 	public ResponseEntity<MembershipAndTicketResponseDTO> getMembershipAndTicket(
 			@AuthMember final String memberId) {
 		return ResponseEntity.ok().body(membershipService.getMembershipAndTicket(memberId));
+	}
+
+	@Override
+	@GetMapping("/payment")
+	public ResponseEntity<PaymentInfoResponseDTO> getNextPaymentInfo(
+			@AuthMember final String memberId) {
+		Optional<PaymentInfoResponseDTO> nextPaymentInfo =
+				membershipService.getNextPaymentInfo(memberId);
+
+		if (nextPaymentInfo.isEmpty()) {
+			return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+		}
+
+		return ResponseEntity.ok().body(nextPaymentInfo.get());
 	}
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/dto/response/GetUsedCouponResponseDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/dto/response/GetUsedCouponResponseDTO.java
@@ -1,0 +1,26 @@
+package com.nonsoolmate.member.controller.dto.response;
+
+import java.util.Optional;
+
+import com.nonsoolmate.coupon.entity.Coupon;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "GetUsedCouponResponseDTO", description = "다음달 결제에 쓰이는 쿠폰 DTO")
+public record GetUsedCouponResponseDTO(
+		@Schema(description = "사용자가 등록한 coupon의 id", example = "1") Long couponId,
+		@Schema(description = "쿠폰 이름", example = "쿠폰 이름입니다.") String couponName,
+		@Schema(description = "쿠폰 이미지 url", example = "[url] 형식") String couponImageUrl,
+		@Schema(description = "RATE 일 경우 할인율", example = "0.2") double discountRate) {
+	public static GetUsedCouponResponseDTO of(Optional<Coupon> coupon) {
+		return coupon
+				.map(
+						value ->
+								new GetUsedCouponResponseDTO(
+										value.getCouponId(),
+										value.getCouponName(),
+										value.getCouponImageUrl(),
+										value.getDiscountRate()))
+				.orElseGet(() -> new GetUsedCouponResponseDTO(null, null, null, 0));
+	}
+}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/dto/response/PaymentInfoResponseDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/dto/response/PaymentInfoResponseDTO.java
@@ -1,0 +1,37 @@
+package com.nonsoolmate.member.controller.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.nonsoolmate.discount.controller.dto.DiscountResponseDTO;
+import com.nonsoolmate.payment.entity.Billing;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "PaymentInfoResponseDTO", description = "다음달 결제 정보 DTO")
+public record PaymentInfoResponseDTO(
+		@Schema(description = "다음 결제일", example = "류가은") LocalDateTime nextPaymentDate,
+		@Schema(description = "결제 수단", example = "카카오뱅크") String paymentMethod,
+		@Schema(description = "카드 번호", example = "53651045****331*") String cardNumber,
+		@Schema(description = "쿠폰 정보", example = "") GetUsedCouponResponseDTO coupon,
+		@Schema(description = "할인 이벤트", example = "") List<DiscountResponseDTO> discountEvent,
+		@Schema(description = "총 할인가", example = "30000") long totalDiscountPrice,
+		@Schema(description = "결제 예정 금액", example = "90000") long totalPrice) {
+	public static PaymentInfoResponseDTO of(
+			LocalDateTime nextPaymentDate,
+			Billing billing,
+			GetUsedCouponResponseDTO coupon,
+			List<DiscountResponseDTO> discountResponseDTOs,
+			long totalDiscountPrice,
+			long totalPrice) {
+
+		return new PaymentInfoResponseDTO(
+				nextPaymentDate,
+				billing.getCardCompany(),
+				billing.getCardNumber(),
+				coupon,
+				discountResponseDTOs,
+				totalDiscountPrice,
+				totalPrice);
+	}
+}

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Membership.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Membership.java
@@ -3,6 +3,7 @@ package com.nonsoolmate.member.entity;
 import static com.nonsoolmate.exception.member.MembershipExceptionType.TERMINATED_MEMBERSHIP;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -21,12 +22,14 @@ import com.nonsoolmate.common.BaseTimeEntity;
 import com.nonsoolmate.exception.member.MemberException;
 import com.nonsoolmate.member.entity.enums.MembershipStatus;
 import com.nonsoolmate.member.entity.enums.MembershipType;
+import com.nonsoolmate.order.entity.OrderDetail;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Membership extends BaseTimeEntity {
 	private static final int MEMBERSHIP_PERIOD = 27;
+	private static final int DAY_1 = 1;
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -61,5 +64,13 @@ public class Membership extends BaseTimeEntity {
 		if (this.status.equals(MembershipStatus.TERMINATED)) {
 			throw new MemberException(TERMINATED_MEMBERSHIP);
 		}
+	}
+
+	public LocalDateTime getExpectedPaymentDate(Optional<OrderDetail> orderDetail) {
+		if (orderDetail.isEmpty()) {
+			return null;
+		}
+
+		return this.endDate.plusDays(DAY_1);
 	}
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/repository/OrderRepository.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/repository/OrderRepository.java
@@ -1,10 +1,12 @@
 package com.nonsoolmate.order.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import com.nonsoolmate.member.entity.Member;
 import com.nonsoolmate.order.entity.OrderDetail;
 
 public interface OrderRepository extends JpaRepository<OrderDetail, Long> {
@@ -16,4 +18,6 @@ public interface OrderRepository extends JpaRepository<OrderDetail, Long> {
 					+ "JOIN FETCH o.couponMember "
 					+ "WHERE o.isPayment = false")
 	List<OrderDetail> findAllByIsPaymentFalse();
+
+	Optional<OrderDetail> findByMemberAndIsPaymentFalse(Member member);
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/product/entity/Product.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/product/entity/Product.java
@@ -3,6 +3,7 @@ package com.nonsoolmate.product.entity;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -17,6 +18,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import com.nonsoolmate.coupon.entity.Coupon;
+import com.nonsoolmate.discountProduct.entity.DiscountProduct;
 import com.nonsoolmate.product.entity.enums.ProductType;
 
 @Entity
@@ -50,5 +53,22 @@ public class Product {
 
 	public List<String> getDescriptions() {
 		return Arrays.asList(description.split(","));
+	}
+
+	public long getDiscountAmount(
+			List<DiscountProduct> discountProduct, Optional<Coupon> usedCoupon) {
+		long productPrice = this.price;
+		long discountAmount = 0;
+
+		for (DiscountProduct discount : discountProduct) {
+			long curDiscountAmount = (long) (productPrice * discount.getDiscount().getDiscountRate());
+			discountAmount += curDiscountAmount;
+			productPrice -= curDiscountAmount;
+		}
+
+		if (usedCoupon.isPresent()) {
+			discountAmount += (long) (productPrice - productPrice * usedCoupon.get().getDiscountRate());
+		}
+		return discountAmount;
 	}
 }


### PR DESCRIPTION
## 📝 PR 타입
- [X] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- closed #164 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 다음 달 결제 정보 조회 API 구현했습니다.

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="797" alt="스크린샷 2024-10-09 오후 6 05 09" src="https://github.com/user-attachments/assets/e8e87698-6286-408a-95b1-b8dded9cda64">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
