### PR TITLE
[FEAT] 카드 정보 조회 시 사용자가 등록한 카드가 없는 경우에 대해 204(No Content) 응답값으로 변경

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardApi.java
@@ -20,11 +20,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public interface CardApi {
   @ApiResponses(
       value = {
-        @ApiResponse(responseCode = "200", description = "사용자 카드 정보 조회에 성공했습니다"),
-        @ApiResponse(
-            responseCode = "404",
-            description = "사용자가 카드를 등록하지 않았습니다",
-            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+        @ApiResponse(responseCode = "200", description = "사용자 등록한 카드 정보 조회에 성공한 경우"),
+        @ApiResponse(responseCode = "204", description = "사용자가 카드를 등록하지 않은 경우")
       })
   @Operation(summary = "카드 등록 페이지: 사용자 카드 정보 조회", description = "사용자가 이전에 등록한 카드 정보를 조회합니다")
   ResponseEntity<CardResponseDTO> getCard(@Parameter(hidden = true) @AuthMember String memberId);

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/controller/CardController.java
@@ -26,7 +26,11 @@ public class CardController implements CardApi {
   @GetMapping
   public ResponseEntity<CardResponseDTO> getCard(@AuthMember final String memberId) {
     CardResponseDTO response = billingService.getCard(memberId);
-    return ResponseEntity.ok(response);
+    boolean hasCard = response != null;
+    if (hasCard) {
+      return ResponseEntity.ok(response);
+    }
+    return ResponseEntity.noContent().build();
   }
 
   @PostMapping("/register")

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/BillingService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/BillingService.java
@@ -1,5 +1,7 @@
 package com.nonsoolmate.payment.service;
 
+import java.util.Optional;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
@@ -23,9 +25,13 @@ public class BillingService {
   private final TossPaymentService tossPaymentService;
 
   public CardResponseDTO getCard(final String memberId) {
-    Billing billing = billingRepository.findByCustomerIdOrThrow(memberId);
-    return CardResponseDTO.of(
-        billing.getBillingId(), billing.getCardCompany(), billing.getCardNumber());
+    Billing billing = billingRepository.findByCustomerMemberId(memberId).orElse(null);
+    boolean hasCard = Optional.ofNullable(billing).isPresent();
+    if (hasCard) {
+      return CardResponseDTO.of(
+          billing.getBillingId(), billing.getCardCompany(), billing.getCardNumber());
+    }
+    return null;
   }
 
   @Transactional

--- a/nonsoolmate-api/src/test/java/com/nonsoolmate/payment/service/BillingServiceTest.java
+++ b/nonsoolmate-api/src/test/java/com/nonsoolmate/payment/service/BillingServiceTest.java
@@ -3,6 +3,8 @@ package com.nonsoolmate.payment.service;
 import static com.nonsoolmate.exception.payment.BillingExceptionType.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.Optional;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -61,13 +63,10 @@ class BillingServiceTest {
   @DisplayName("사용자가 카드를 등록하지 않은 경우")
   void getCardTestWhenMemberHasNotRegisteredCard() {
     // given
-    given(billingRepository.findByCustomerIdOrThrow(anyString()))
-        .willThrow(new BillingException(NOT_FOUND_BILLING));
+    given(billingRepository.findByCustomerMemberId(anyString())).willReturn(Optional.empty());
 
     // when, then
-    Assertions.assertThatThrownBy(() -> billingService.getCard(MEMBER_ID))
-        .isInstanceOf(BillingException.class)
-        .hasMessage(NOT_REGISTERED_CARD_EXCEPTION_MESSAGE);
+    Assertions.assertThat(billingService.getCard(MEMBER_ID)).isNull();
   }
 
   @Test

--- a/nonsoolmate-api/src/test/java/com/nonsoolmate/payment/service/BillingServiceTest.java
+++ b/nonsoolmate-api/src/test/java/com/nonsoolmate/payment/service/BillingServiceTest.java
@@ -50,7 +50,8 @@ class BillingServiceTest {
     Member expectedMember = getExpectedMember();
     Billing expectedBilling = getExpectedBilling(expectedMember);
     CardResponseDTO expectedResponse = getExpectedCardResponseDTO(expectedBilling);
-    given(billingRepository.findByCustomerIdOrThrow(anyString())).willReturn(expectedBilling);
+    given(billingRepository.findByCustomerMemberId(anyString()))
+        .willReturn(Optional.of(expectedBilling));
 
     // when
     CardResponseDTO response = billingService.getCard(MEMBER_ID);


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#194 -> dev
- closed #194 


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 사용자가 카드를 등록하지 않고 조회하는 경우에 대해 결제 페이지에서는 플로우가 예외는 아닌 것 같아 404 not found에서 No Content로 변경했습니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 카드가 없는 경우
<img width="854" alt="image" src="https://github.com/user-attachments/assets/8aea0ed5-5a0a-47b8-b06f-6756b73e43ce">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
