### PR TITLE
[FEAT] 멤버십 상태 변경 API 구현

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MembershipApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MembershipApi.java
@@ -1,9 +1,13 @@
 package com.nonsoolmate.member.controller;
 
+import jakarta.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 
 import com.nonsoolmate.global.security.AuthMember;
+import com.nonsoolmate.member.controller.dto.request.MembershipStatusRequestDTO;
 import com.nonsoolmate.member.controller.dto.response.MembershipAndTicketResponseDTO;
+import com.nonsoolmate.member.controller.dto.response.MembershipStatusResponseDTO;
 import com.nonsoolmate.member.controller.dto.response.PaymentInfoResponseDTO;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,4 +27,15 @@ public interface MembershipApi {
   @Operation(summary = "다음달 결제 정보", description = "다음달 결제 정보를 조회합니다.")
   ResponseEntity<PaymentInfoResponseDTO> getNextPaymentInfo(
       @Parameter(hidden = true) @AuthMember String memberId);
+
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "멤버십 상태 변경에 성공한 경우"),
+        @ApiResponse(responseCode = "404", description = "멤버십 구매를 하지 않았는데 상태 변경을 요청하는 경우")
+      })
+  @Operation(summary = "멤버십 상태 변경", description = "멤버십 상태를 변경합니다.")
+  ResponseEntity<MembershipStatusResponseDTO> changeMembershipStatus(
+      @Parameter(hidden = true) @AuthMember String memberId,
+      @Parameter(description = "멤버십 변경 요청 dto", required = true) @Valid
+          MembershipStatusRequestDTO request);
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MembershipController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MembershipController.java
@@ -2,16 +2,22 @@ package com.nonsoolmate.member.controller;
 
 import java.util.Optional;
 
+import jakarta.validation.Valid;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.nonsoolmate.global.security.AuthMember;
+import com.nonsoolmate.member.controller.dto.request.MembershipStatusRequestDTO;
 import com.nonsoolmate.member.controller.dto.response.MembershipAndTicketResponseDTO;
+import com.nonsoolmate.member.controller.dto.response.MembershipStatusResponseDTO;
 import com.nonsoolmate.member.controller.dto.response.PaymentInfoResponseDTO;
 import com.nonsoolmate.member.service.MembershipService;
 
@@ -41,5 +47,15 @@ public class MembershipController implements MembershipApi {
     }
 
     return ResponseEntity.ok().body(nextPaymentInfo.get());
+  }
+
+  @Override
+  @PatchMapping("/status")
+  public ResponseEntity<MembershipStatusResponseDTO> changeMembershipStatus(
+      @AuthMember final String memberId,
+      @Valid @RequestBody final MembershipStatusRequestDTO request) {
+    MembershipStatusResponseDTO response =
+        membershipService.changeMembershipStatus(memberId, request);
+    return ResponseEntity.ok().body(response);
   }
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/dto/request/MembershipStatusRequestDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/dto/request/MembershipStatusRequestDTO.java
@@ -1,0 +1,12 @@
+package com.nonsoolmate.member.controller.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import com.nonsoolmate.member.entity.enums.MembershipStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "MembershipStatusRequestDTO", description = "멤버십 상태 수정 요청 DTO")
+public record MembershipStatusRequestDTO(
+    @Schema(description = "멤버십 상태 / 해지하는 경우: TERMINATED, 연장하는 경우: IN_PROGRESS") @NotNull
+        MembershipStatus status) {}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/dto/response/MembershipStatusResponseDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/dto/response/MembershipStatusResponseDTO.java
@@ -1,0 +1,32 @@
+package com.nonsoolmate.member.controller.dto.response;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.nonsoolmate.member.entity.enums.MembershipStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "MembershipStatusResponseDTO", description = "멤버십 정보 응답 DTO")
+public record MembershipStatusResponseDTO(
+    @Schema(
+            description = "멤버십 상태(IN_PROGRESS: 진행중일 때 / TERMINATED: 해지했을 때)",
+            example = "IN_PROGRESS")
+        MembershipStatus status,
+    @Schema(description = "멤버십 이름", example = "베이직 플랜") String membershipName,
+    @Schema(description = "멤버십 이용 기간", example = "2024.10.01 ~ 2024.10.28")
+        String membershipUsingDate) {
+  public static MembershipStatusResponseDTO of(
+      final MembershipStatus status,
+      final String membershipName,
+      final LocalDateTime startDate,
+      final LocalDateTime endDate) {
+    String membershipUsingDate = dateFormating(startDate, endDate);
+    return new MembershipStatusResponseDTO(status, membershipName, membershipUsingDate);
+  }
+
+  private static String dateFormating(LocalDateTime startDate, LocalDateTime endDate) {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+    return startDate.format(formatter) + " ~ " + endDate.format(formatter);
+  }
+}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/service/MembershipService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/service/MembershipService.java
@@ -14,8 +14,10 @@ import com.nonsoolmate.coupon.repository.CouponRepository;
 import com.nonsoolmate.discount.controller.dto.DiscountResponseDTO;
 import com.nonsoolmate.discountProduct.entity.DiscountProduct;
 import com.nonsoolmate.discountProduct.repository.DiscountProductRepository;
+import com.nonsoolmate.member.controller.dto.request.MembershipStatusRequestDTO;
 import com.nonsoolmate.member.controller.dto.response.GetUsedCouponResponseDTO;
 import com.nonsoolmate.member.controller.dto.response.MembershipAndTicketResponseDTO;
+import com.nonsoolmate.member.controller.dto.response.MembershipStatusResponseDTO;
 import com.nonsoolmate.member.controller.dto.response.PaymentInfoResponseDTO;
 import com.nonsoolmate.member.entity.Member;
 import com.nonsoolmate.member.entity.Membership;
@@ -115,5 +117,17 @@ public class MembershipService {
             discountResponseDTOs,
             totalDiscountPrice,
             totalPrice));
+  }
+
+  public MembershipStatusResponseDTO changeMembershipStatus(
+      final String memberId, final MembershipStatusRequestDTO request) {
+    Member member = memberRepository.findByMemberIdOrThrow(memberId);
+    Membership membership = membershipRepository.findByMemberOrThrow(member);
+    membership.changeMembershipStatus(request.status());
+    return MembershipStatusResponseDTO.of(
+        membership.getStatus(),
+        membership.getMembershipType().getDescription(),
+        membership.getStartDate(),
+        membership.getEndDate());
   }
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Member.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Member.java
@@ -98,8 +98,8 @@ public class Member extends BaseTimeEntity {
   }
 
   public void updateTicketCount(int reviewTicketCount, int reReviewTicketCount) {
-    this.reviewTicketCount += reviewTicketCount;
-    this.reReviewTicketCount += reReviewTicketCount;
+    this.reviewTicketCount = reviewTicketCount;
+    this.reReviewTicketCount = reReviewTicketCount;
   }
 
   public void updateMemberProfile(

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Membership.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/Membership.java
@@ -73,4 +73,8 @@ public class Membership extends BaseTimeEntity {
 
     return this.endDate.plusDays(DAY_1);
   }
+
+  public void changeMembershipStatus(MembershipStatus status) {
+    this.status = status;
+  }
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/enums/MembershipType.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/entity/enums/MembershipType.java
@@ -4,11 +4,13 @@ import static com.nonsoolmate.exception.member.MembershipExceptionType.*;
 
 import java.util.Arrays;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import com.nonsoolmate.exception.common.BusinessException;
 
 @RequiredArgsConstructor
+@Getter
 public enum MembershipType {
   NONE("멤버십 없음"),
   BASIC("베이직 플랜"),

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/repository/MembershipRepository.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/repository/MembershipRepository.java
@@ -1,6 +1,6 @@
 package com.nonsoolmate.member.repository;
 
-import static com.nonsoolmate.exception.member.MembershipExceptionType.NOT_FOUND_MEMBERSHIP_TYPE;
+import static com.nonsoolmate.exception.member.MembershipExceptionType.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,7 +26,7 @@ public interface MembershipRepository extends JpaRepository<Membership, Long> {
   Optional<Membership> findByMember(final Member member);
 
   default Membership findByMemberOrThrow(Member member) {
-    return findByMember(member).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBERSHIP_TYPE));
+    return findByMember(member).orElseThrow(() -> new MemberException(NOT_FOUND_MEMBERSHIP));
   }
 
   List<Membership> findAllByStatusAndMemberIn(

--- a/nonsoolmate-exception/src/main/java/com/nonsoolmate/exception/member/MembershipExceptionType.java
+++ b/nonsoolmate-exception/src/main/java/com/nonsoolmate/exception/member/MembershipExceptionType.java
@@ -10,6 +10,7 @@ import com.nonsoolmate.exception.common.ExceptionType;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum MembershipExceptionType implements ExceptionType {
   NOT_FOUND_MEMBERSHIP_TYPE(HttpStatus.NOT_FOUND, "존재하지 않는 멤버십 타입입니다."),
+  NOT_FOUND_MEMBERSHIP(HttpStatus.NOT_FOUND, "멤버십이 존재하지 않습니다."),
   TERMINATED_MEMBERSHIP(HttpStatus.BAD_REQUEST, "이미 해지된 멤버십 입니다.");
 
   private final HttpStatus status;


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#173 -> dev
- closed #173 


## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 멤버십 상태를 변경하는 API를 구현했습니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 해지로 변경
<img width="853" alt="스크린샷 2024-10-10 오후 9 37 09" src="https://github.com/user-attachments/assets/9f0aaa29-60b2-4b1c-b6d9-7b535cfa52c2">

- 연장하기로 변경
<img width="851" alt="스크린샷 2024-10-10 오후 9 37 28" src="https://github.com/user-attachments/assets/a13dd281-bfe7-4a3e-8dc5-d5efff51c32f">

- 멤버십이 없는 상태에서 상태 변경을 요청하는 경우
<img width="849" alt="스크린샷 2024-10-10 오후 9 57 38" src="https://github.com/user-attachments/assets/2f5fde81-951f-473f-b675-1412501e3d60">

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
