### PR TITLE
[FEAT] 멤버십 조회 API 구현

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MembershipApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MembershipApi.java
@@ -38,4 +38,13 @@ public interface MembershipApi {
       @Parameter(hidden = true) @AuthMember String memberId,
       @Parameter(description = "멤버십 변경 요청 dto", required = true) @Valid
           MembershipStatusRequestDTO request);
+
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "멤버십 조회에 성공한 경우"),
+        @ApiResponse(responseCode = "204", description = "멤버십 구매를 하지 않았는데 멤버십 조회를 요청하는 경우")
+      })
+  @Operation(summary = "멤버십 상태 변경", description = "멤버십 상태를 변경합니다.")
+  ResponseEntity<MembershipStatusResponseDTO> getMembership(
+      @Parameter(hidden = true) @AuthMember String memberId);
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MembershipController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MembershipController.java
@@ -58,4 +58,16 @@ public class MembershipController implements MembershipApi {
         membershipService.changeMembershipStatus(memberId, request);
     return ResponseEntity.ok().body(response);
   }
+
+  @Override
+  @GetMapping("")
+  public ResponseEntity<MembershipStatusResponseDTO> getMembership(
+      @AuthMember final String memberId) {
+    MembershipStatusResponseDTO response = membershipService.getMembership(memberId);
+    boolean isMembershipEmpty = response == null;
+    if (isMembershipEmpty) {
+      return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+    return ResponseEntity.ok().body(response);
+  }
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/service/MembershipService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/service/MembershipService.java
@@ -51,6 +51,19 @@ public class MembershipService {
         member.getReReviewTicketCount());
   }
 
+  public MembershipStatusResponseDTO getMembership(final String memberId) {
+    Member member = memberRepository.findByMemberIdOrThrow(memberId);
+    Membership membership = membershipRepository.findByMember(member).orElse(null);
+    if (membership == null) {
+      return null;
+    }
+    return MembershipStatusResponseDTO.of(
+        membership.getStatus(),
+        membership.getMembershipType().getDescription(),
+        membership.getStartDate(),
+        membership.getEndDate());
+  }
+
   private MembershipType getMembershipType(final Member member) {
     MembershipType membershipType = membershipRepository.findMembershipTypeOrThrowNull(member);
     boolean existMembership = membershipType != null;


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#172 -> dev
- closed #172

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 멤버십이 존재하는 경우에는 OK, 없는 경우에는 NoContent로 응답합니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 멤버십이 존재하지 않는 경우
<img width="843" alt="스크린샷 2024-10-11 오후 9 40 28" src="https://github.com/user-attachments/assets/9b12f954-d853-40a5-8e73-ccad7000fa5c">

- 멤버십이 존재하는 경우
<img width="838" alt="스크린샷 2024-10-11 오후 9 40 48" src="https://github.com/user-attachments/assets/ec4aa23f-b385-4c3a-bb3e-0db020f284d9">


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
