### PR TITLE
[FEAT] 멤버십을 해지하고 유효기간이 지난 회원을 membership 테이블에서 삭제하는 스케줄러 구현

### DIFF
--- a/nonsoolmate-batch/src/main/java/com/nonsoolmate/scheduler/BillingScheduler.java
+++ b/nonsoolmate-batch/src/main/java/com/nonsoolmate/scheduler/BillingScheduler.java
@@ -1,4 +1,4 @@
-package com.nonsoolmate.payment;
+package com.nonsoolmate.scheduler;
 
 import java.util.List;
 import java.util.Map;
@@ -16,6 +16,7 @@ import com.nonsoolmate.member.entity.enums.MembershipStatus;
 import com.nonsoolmate.member.repository.MembershipRepository;
 import com.nonsoolmate.order.entity.OrderDetail;
 import com.nonsoolmate.order.repository.OrderRepository;
+import com.nonsoolmate.service.BillingPaymentService;
 
 @Service
 @RequiredArgsConstructor

--- a/nonsoolmate-batch/src/main/java/com/nonsoolmate/scheduler/MembershipScheduler.java
+++ b/nonsoolmate-batch/src/main/java/com/nonsoolmate/scheduler/MembershipScheduler.java
@@ -1,0 +1,24 @@
+package com.nonsoolmate.scheduler;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.nonsoolmate.member.repository.MembershipRepository;
+
+@Service
+@RequiredArgsConstructor
+public class MembershipScheduler {
+  private final MembershipRepository membershipRepository;
+
+  @Scheduled(cron = "0 0 0 * * *")
+  @Transactional
+  public void removeExpiredMemberships() {
+    List<Long> expiredMembershipIds = membershipRepository.findExpiredMembershipIds();
+    membershipRepository.deleteAllByIdInBatch(expiredMembershipIds);
+  }
+}

--- a/nonsoolmate-batch/src/main/java/com/nonsoolmate/service/BillingPaymentService.java
+++ b/nonsoolmate-batch/src/main/java/com/nonsoolmate/service/BillingPaymentService.java
@@ -1,4 +1,4 @@
-package com.nonsoolmate.payment;
+package com.nonsoolmate.service;
 
 import java.util.Map;
 
@@ -15,7 +15,6 @@ import com.nonsoolmate.member.entity.Member;
 import com.nonsoolmate.member.entity.Membership;
 import com.nonsoolmate.member.entity.enums.MembershipType;
 import com.nonsoolmate.order.entity.OrderDetail;
-import com.nonsoolmate.service.PaymentCommonService;
 import com.nonsoolmate.toss.service.TossPaymentService;
 
 @Service

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/repository/MembershipRepository.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/member/repository/MembershipRepository.java
@@ -31,4 +31,8 @@ public interface MembershipRepository extends JpaRepository<Membership, Long> {
 
   List<Membership> findAllByStatusAndMemberIn(
       MembershipStatus membershipStatus, List<Member> members);
+
+  @Query(
+      "SELECT m.membershipId FROM Membership m WHERE m.status = 'TERMINATED' AND m.endDate < CURRENT_DATE")
+  List<Long> findExpiredMembershipIds();
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#174 -> dev
- closed #174 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 멤버십을 삭제해야 할 회원들의 membershipId를 조회하여 한번에 삭제하는 기능을 구현했습니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 스케줄러 가동 전
![스크린샷 2024-10-11 오후 10 03 26](https://github.com/user-attachments/assets/66f813ca-4fb0-462f-9108-5a2356b8b007)

- 스케줄러 가동 후
![스크린샷 2024-10-11 오후 10 15 57](https://github.com/user-attachments/assets/ad50089e-e4e9-413b-834b-4db5fcdb889b)

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 스케줄러 모듈은 현재 배포되지 않고 있는게 맞을까요??