### PR TITLE
[FIX] 모달창, 멤버십 조회 응답값 수정

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MembershipApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/MembershipApi.java
@@ -44,7 +44,7 @@ public interface MembershipApi {
         @ApiResponse(responseCode = "200", description = "멤버십 조회에 성공한 경우"),
         @ApiResponse(responseCode = "204", description = "멤버십 구매를 하지 않았는데 멤버십 조회를 요청하는 경우")
       })
-  @Operation(summary = "멤버십 상태 변경", description = "멤버십 상태를 변경합니다.")
+  @Operation(summary = "멤버십 조회", description = "멤버십 상태를 조회합니다")
   ResponseEntity<MembershipStatusResponseDTO> getMembership(
       @Parameter(hidden = true) @AuthMember String memberId);
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/dto/response/MembershipAndTicketResponseDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/dto/response/MembershipAndTicketResponseDTO.java
@@ -8,15 +8,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record MembershipAndTicketResponseDTO(
     @Schema(description = "멤버 이름", example = "류가은") String memberName,
     @Schema(description = "멤버십 유형", example = "BASIC") MembershipType membershipType,
+    @Schema(description = "멤버 성별 (남자: M, 여자: F, 선택안함: null", example = "M") String gender,
     @Schema(description = "사용자 첨삭권 개수", example = "5") int reviewTicketCount,
     @Schema(description = "사용자 재첨삭권 개수", example = "5") int reReviewticketCount) {
   public static MembershipAndTicketResponseDTO of(
       final String memberName,
       final MembershipType membershipType,
+      final String gender,
       final int reviewTicketCount,
       final int reReviewticketCount) {
 
     return new MembershipAndTicketResponseDTO(
-        memberName, membershipType, reviewTicketCount, reReviewticketCount);
+        memberName, membershipType, gender, reviewTicketCount, reReviewticketCount);
   }
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/dto/response/MembershipStatusResponseDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/controller/dto/response/MembershipStatusResponseDTO.java
@@ -14,19 +14,21 @@ public record MembershipStatusResponseDTO(
             example = "IN_PROGRESS")
         MembershipStatus status,
     @Schema(description = "멤버십 이름", example = "베이직 플랜") String membershipName,
-    @Schema(description = "멤버십 이용 기간", example = "2024.10.01 ~ 2024.10.28")
-        String membershipUsingDate) {
+    @Schema(description = "멤버십 시작 기간", example = "2024.10.01") String startDate,
+    @Schema(description = "멤버십 종료 기간", example = "2024.10.28") String endDate) {
   public static MembershipStatusResponseDTO of(
       final MembershipStatus status,
       final String membershipName,
       final LocalDateTime startDate,
       final LocalDateTime endDate) {
-    String membershipUsingDate = dateFormating(startDate, endDate);
-    return new MembershipStatusResponseDTO(status, membershipName, membershipUsingDate);
+    String formattedStartDate = dateFormating(startDate);
+    String formattedEndDate = dateFormating(endDate);
+    return new MembershipStatusResponseDTO(
+        status, membershipName, formattedStartDate, formattedEndDate);
   }
 
-  private static String dateFormating(LocalDateTime startDate, LocalDateTime endDate) {
+  private static String dateFormating(LocalDateTime date) {
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
-    return startDate.format(formatter) + " ~ " + endDate.format(formatter);
+    return date.format(formatter);
   }
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/member/service/MembershipService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/member/service/MembershipService.java
@@ -47,6 +47,7 @@ public class MembershipService {
     return MembershipAndTicketResponseDTO.of(
         member.getName(),
         membershipType,
+        member.getGender(),
         member.getReviewTicketCount(),
         member.getReReviewTicketCount());
   }

--- a/nonsoolmate-api/src/test/java/com/nonsoolmate/member/service/MembershipServiceTest.java
+++ b/nonsoolmate-api/src/test/java/com/nonsoolmate/member/service/MembershipServiceTest.java
@@ -87,6 +87,7 @@ class MembershipServiceTest {
     return Member.builder()
         .email("testEmail")
         .name("testName")
+        .gender("M")
         .platformType(PlatformType.NAVER)
         .platformId("testPlatformId")
         .role(Role.USER)
@@ -96,6 +97,6 @@ class MembershipServiceTest {
 
   private MembershipAndTicketResponseDTO getExpectedMembershipAndTicketResponseDTO(
       MembershipType membershipType) {
-    return MembershipAndTicketResponseDTO.of(MEMBER_NAME, membershipType, 0, 0);
+    return MembershipAndTicketResponseDTO.of(MEMBER_NAME, membershipType, "M", 0, 0);
   }
 }


### PR DESCRIPTION
## 📝 PR 타입
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- fix/#206 -> dev
- closed #206 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 모달창에서 성별에 대한 필드값을 추가했습니다
- 멤버십 조회에서 멤버십 시작날짜와 종료날짜를 구분하여 보내도록 수정했습니다

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 모달창
![image](https://github.com/user-attachments/assets/36c96aec-b9ed-417c-ba68-da6bccaa36f7)

- 멤버십 조회
![image](https://github.com/user-attachments/assets/b52799e5-31a7-4b92-a9fd-d87515f0ec91)


## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
