### PR TITLE
[FEAT] 첨삭 상태 변경 시 이메일 발송 로직 구현

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/EditingResultApi.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/EditingResultApi.java
@@ -1,9 +1,12 @@
 package com.nonsoolmate.examRecord.controller;
 
+import jakarta.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.nonsoolmate.examRecord.controller.dto.request.UpdateExamRecordResultRequestDTO;
 import com.nonsoolmate.examRecord.controller.dto.response.EditingResultDTO;
 import com.nonsoolmate.examRecord.entity.enums.EditingType;
 import com.nonsoolmate.global.security.AuthMember;
@@ -35,4 +38,16 @@ public interface EditingResultApi {
           @RequestParam("type")
           final EditingType type,
       @Parameter(hidden = true) @AuthMember final String memberId);
+
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200"),
+        @ApiResponse(
+            responseCode = "404",
+            description = "존재하지 않는 시험 응시 기록입니다",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+      })
+  ResponseEntity<EditingResultDTO> updateExamRecordResult(
+      @Parameter(description = "첨삭 결과 등록 request") @Valid
+          final UpdateExamRecordResultRequestDTO request);
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/EditingResultController.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/EditingResultController.java
@@ -1,14 +1,19 @@
 package com.nonsoolmate.examRecord.controller;
 
+import jakarta.validation.Valid;
+
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.nonsoolmate.examRecord.controller.dto.request.UpdateExamRecordResultRequestDTO;
 import com.nonsoolmate.examRecord.controller.dto.response.EditingResultDTO;
 import com.nonsoolmate.examRecord.entity.enums.EditingType;
 import com.nonsoolmate.examRecord.service.ExamRecordService;
@@ -27,5 +32,12 @@ public class EditingResultController implements EditingResultApi {
       @AuthMember final String memberId) {
     return ResponseEntity.ok()
         .body(examRecordService.getExamRecordEditingResult(examId, type, memberId));
+  }
+
+  // for admin
+  @PatchMapping("/result")
+  public ResponseEntity<EditingResultDTO> updateExamRecordResult(
+      @Valid @RequestBody final UpdateExamRecordResultRequestDTO request) {
+    return ResponseEntity.ok().body(examRecordService.updateExamRecordEditingResult(request));
   }
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/dto/request/CreateExamRecordRequestDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/dto/request/CreateExamRecordRequestDTO.java
@@ -12,7 +12,7 @@ public record CreateExamRecordRequestDTO(
     @NotNull @Schema(description = "대학 시험 id", example = "1") Long examId,
     @Positive @Schema(description = "사용자가 해당 시험을 보는데 걸린 시간(초 단위)") int memberTakeTimeExam,
     @NotNull @Schema(description = "PreSingedUrl 발급 시 전달 받은 파일 이름") String memberSheetFileName,
-    @NotNull @Schema(description = "첨삭 유형(EDITING, REVISION)", example = "REVIEW")
+    @NotNull @Schema(description = "첨삭 유형(EDITING, REVISION)", example = "REVISION")
         EditingType editingType) {
   public static CreateExamRecordRequestDTO of(
       Long examId, int memberTakeTimeExam, String memberSheetFileName, EditingType editingType) {

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/dto/request/UpdateExamRecordResultRequestDTO.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/controller/dto/request/UpdateExamRecordResultRequestDTO.java
@@ -1,0 +1,15 @@
+package com.nonsoolmate.examRecord.controller.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+import com.nonsoolmate.examRecord.entity.enums.EditingType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "UpdateExamRecordResultRequestDTO", description = "대학 시험 첨삭 결과 수정 요청 DTO")
+public record UpdateExamRecordResultRequestDTO(
+    @NotNull @Schema(description = "대학 시험 id", example = "1") Long examId,
+    @NotNull @Schema(description = "회원 id", example = "xmdhehdjfewl") String memberId,
+    @NotNull @Schema(description = "첨삭 유형(EDITING, REVISION)", example = "EDITING")
+        EditingType editingType,
+    @NotNull @Schema(description = "S3 버킷에 업로드 된 파일명") String examResultFileName) {}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/service/ExamRecordService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/examRecord/service/ExamRecordService.java
@@ -109,11 +109,11 @@ public class ExamRecordService {
     }
 
     String email = examRecord.getMember().getEmail();
-    String status = examRecord.getExamResultStatus().getStatus();
+    String editingType = examRecord.getEditingType().getType();
     String examFullName = examRecord.getExam().getExamFullName();
 
     emailEventListener.publishExamRecordStatusUpdatedEvent(
-        ExamRecordStatusUpdatedEvent.of(email, status, examFullName));
+        ExamRecordStatusUpdatedEvent.of(email, editingType, examFullName));
 
     return EditingResultDTO.of(
         request.editingType(),

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/global/config/AsyncConfig.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/global/config/AsyncConfig.java
@@ -1,0 +1,8 @@
+package com.nonsoolmate.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/global/config/SecurityConfig.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/global/config/SecurityConfig.java
@@ -101,6 +101,7 @@ public class SecurityConfig {
             auth -> {
               auth.requestMatchers(AUTH_WHITELIST).permitAll();
               auth.requestMatchers(AUTH_WHITELIST_WILDCARD).permitAll();
+              auth.requestMatchers("/college/exam-record/result").hasAuthority("ADMIN");
               auth.anyRequest().authenticated();
             })
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/global/event/EmailEventListener.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/global/event/EmailEventListener.java
@@ -1,0 +1,21 @@
+package com.nonsoolmate.global.event;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import com.nonsoolmate.email.service.EmailService;
+
+@Component
+@RequiredArgsConstructor
+public class EmailEventListener {
+  private final EmailService emailService;
+
+  @Async
+  @EventListener
+  public void publishExamRecordStatusUpdatedEvent(ExamRecordStatusUpdatedEvent event) {
+    emailService.sendMessage(event.email());
+  }
+}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/global/event/EmailEventListener.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/global/event/EmailEventListener.java
@@ -2,9 +2,10 @@ package com.nonsoolmate.global.event;
 
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.nonsoolmate.email.service.EmailService;
 
@@ -14,7 +15,7 @@ public class EmailEventListener {
   private final EmailService emailService;
 
   @Async
-  @EventListener
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void publishExamRecordStatusUpdatedEvent(ExamRecordStatusUpdatedEvent event) {
     emailService.sendMessageAboutExamRecordStatus(
         event.email(), event.editingType(), event.examFullName());

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/global/event/EmailEventListener.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/global/event/EmailEventListener.java
@@ -16,6 +16,7 @@ public class EmailEventListener {
   @Async
   @EventListener
   public void publishExamRecordStatusUpdatedEvent(ExamRecordStatusUpdatedEvent event) {
-    emailService.sendMessage(event.email());
+    emailService.sendMessageAboutExamRecordStatus(
+        event.email(), event.editingType(), event.examFullName());
   }
 }

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/global/event/ExamRecordStatusUpdatedEvent.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/global/event/ExamRecordStatusUpdatedEvent.java
@@ -1,0 +1,7 @@
+package com.nonsoolmate.global.event;
+
+public record ExamRecordStatusUpdatedEvent(String email, String status, String examFullName) {
+  public static ExamRecordStatusUpdatedEvent of(String email, String status, String examFullName) {
+    return new ExamRecordStatusUpdatedEvent(email, status, examFullName);
+  }
+}

--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/global/event/ExamRecordStatusUpdatedEvent.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/global/event/ExamRecordStatusUpdatedEvent.java
@@ -1,7 +1,8 @@
 package com.nonsoolmate.global.event;
 
-public record ExamRecordStatusUpdatedEvent(String email, String status, String examFullName) {
-  public static ExamRecordStatusUpdatedEvent of(String email, String status, String examFullName) {
-    return new ExamRecordStatusUpdatedEvent(email, status, examFullName);
+public record ExamRecordStatusUpdatedEvent(String email, String editingType, String examFullName) {
+  public static ExamRecordStatusUpdatedEvent of(
+      String email, String editingType, String examFullName) {
+    return new ExamRecordStatusUpdatedEvent(email, editingType, examFullName);
   }
 }

--- a/nonsoolmate-api/src/main/resources/application-dev.yml
+++ b/nonsoolmate-api/src/main/resources/application-dev.yml
@@ -43,6 +43,18 @@ spring:
       host: redis
       port: 6379
 
+  mail:
+    host: smtp.naver.com
+    port: ${SMTP_PORT}
+    username: ${SMTP_USERNAME}
+    password: ${SMTP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 aws-property:
   access-key: ${DEV_AWS_ACCESS_KEY}
   secret-key: ${DEV_AWS_SECRET_KEY}

--- a/nonsoolmate-api/src/main/resources/application-local.yml
+++ b/nonsoolmate-api/src/main/resources/application-local.yml
@@ -49,6 +49,18 @@ spring:
       enabled: true
       path: /h2-console
 
+  mail:
+    host: smtp.naver.com
+    port: ${SMTP_PORT}
+    username: ${SMTP_USERNAME}
+    password: ${SMTP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 aws-property:
   access-key: ${DEV_AWS_ACCESS_KEY}
   secret-key: ${DEV_AWS_SECRET_KEY}

--- a/nonsoolmate-api/src/main/resources/application-prod.yml
+++ b/nonsoolmate-api/src/main/resources/application-prod.yml
@@ -44,7 +44,7 @@ spring:
 
   mail:
     host: smtp.naver.com
-    port: ${SMTP_PORT }
+    port: ${SMTP_PORT}
     username: ${SMTP_USERNAME}
     password: ${SMTP_PASSWORD}
     properties:

--- a/nonsoolmate-api/src/main/resources/application-prod.yml
+++ b/nonsoolmate-api/src/main/resources/application-prod.yml
@@ -42,6 +42,18 @@ spring:
       host: redis
       port: 6379
 
+  mail:
+    host: smtp.naver.com
+    port: ${SMTP_PORT }
+    username: ${SMTP_USERNAME}
+    password: ${SMTP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 
 aws-property:
   access-key: ${PROD_AWS_ACCESS_KEY}

--- a/nonsoolmate-api/src/main/resources/application-test.yml
+++ b/nonsoolmate-api/src/main/resources/application-test.yml
@@ -51,6 +51,18 @@ spring:
       enabled: true
       path: /h2-console
 
+  mail:
+    host: smtp.naver.com
+    port: ${SMTP_PORT}
+    username: ${SMTP_USERNAME}
+    password: ${SMTP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 aws-property:
   access-key: ${DEV_AWS_ACCESS_KEY}
   secret-key: ${DEV_AWS_SECRET_KEY}

--- a/nonsoolmate-batch/src/main/resources/application.yml
+++ b/nonsoolmate-batch/src/main/resources/application.yml
@@ -31,6 +31,17 @@ spring:
           token-uri:
             host: ${OAUTH2_NAVER_TOKEN_URI_HOST}
             path: ${OAUTH2_NAVER_TOKEN_URI_PATH}
+  mail:
+    host: smtp.naver.com
+    port: ${SMTP_PORT}
+    username: ${SMTP_USERNAME}
+    password: ${SMTP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
 
 aws-property:
   access-key: ${PROD_AWS_ACCESS_KEY}

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/examRecord/entity/ExamRecord.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/examRecord/entity/ExamRecord.java
@@ -75,4 +75,12 @@ public class ExamRecord extends BaseTimeEntity {
     this.timeTakeExam = timeTakeExam;
     this.examRecordSheetFileName = examRecordSheetFileName;
   }
+
+  public void updateExamRecordResultFileName(final String examRecordResultFileName) {
+    this.examRecordResultFileName = examRecordResultFileName;
+  }
+
+  public void updateExamResultStatus(ExamResultStatus examResultStatus) {
+    this.examResultStatus = examResultStatus;
+  }
 }

--- a/nonsoolmate-external/build.gradle
+++ b/nonsoolmate-external/build.gradle
@@ -18,6 +18,9 @@ dependencies {
     // webclient
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
+    // mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
     // spring
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/nonsoolmate-external/build.gradle
+++ b/nonsoolmate-external/build.gradle
@@ -21,6 +21,9 @@ dependencies {
     // mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+    // thymeleaf
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
     // spring
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/email/config/EmailConfig.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/email/config/EmailConfig.java
@@ -2,8 +2,6 @@ package com.nonsoolmate.email.config;
 
 import java.util.Properties;
 
-import lombok.Getter;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,7 +9,6 @@ import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 
 @Configuration
-@Getter
 public class EmailConfig {
   @Value("${spring.mail.host}")
   private String mailServerHost;
@@ -38,7 +35,6 @@ public class EmailConfig {
     JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
     mailSender.setHost(mailServerHost);
     mailSender.setPassword(mailServerPort);
-
     mailSender.setUsername(mailServerUsername);
     mailSender.setPassword(mailServerPassword);
 

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/email/config/EmailConfig.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/email/config/EmailConfig.java
@@ -6,11 +6,11 @@ import lombok.Getter;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
-import org.springframework.stereotype.Component;
 
-@Component
+@Configuration
 @Getter
 public class EmailConfig {
   @Value("${spring.mail.host}")

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/email/config/EmailConfig.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/email/config/EmailConfig.java
@@ -1,0 +1,52 @@
+package com.nonsoolmate.email.config;
+
+import java.util.Properties;
+
+import lombok.Getter;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+import org.springframework.stereotype.Component;
+
+@Component
+@Getter
+public class EmailConfig {
+  @Value("${spring.mail.host}")
+  private String mailServerHost;
+
+  @Value("${spring.mail.port}")
+  private String mailServerPort;
+
+  @Value("${spring.mail.username}")
+  private String mailServerUsername;
+
+  @Value("${spring.mail.password}")
+  private String mailServerPassword;
+
+  @Value("${spring.mail.properties.mail.smtp.auth}")
+  private String mailServerAuth;
+
+  @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+  private String mailServerStarttlsEnable;
+
+  private static final String MAIL_SERVER_PROTOCOL = "smtp";
+
+  @Bean
+  public JavaMailSender javaMailSender() {
+    JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+    mailSender.setHost(mailServerHost);
+    mailSender.setPassword(mailServerPort);
+
+    mailSender.setUsername(mailServerUsername);
+    mailSender.setPassword(mailServerPassword);
+
+    Properties properties = mailSender.getJavaMailProperties();
+    properties.put("mail.transport.protocol", MAIL_SERVER_PROTOCOL);
+    properties.put("mail.smtp.auth", mailServerAuth);
+    properties.put("mail.smtp.starttls.enable", mailServerStarttlsEnable);
+
+    return mailSender;
+  }
+}

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/email/service/EmailService.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/email/service/EmailService.java
@@ -16,19 +16,19 @@ public class EmailService {
   private final JavaMailSender mailSender;
   private final EmailConfig emailConfig;
 
-  public void sendMessage(String email) {
+  public void sendMessageAboutExamRecordStatus(
+      String email, String editingType, String examFullName) {
     MimeMessage mimeMessage = mailSender.createMimeMessage();
 
     try {
-      MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+      MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
 
-      // 메일을 받을 수신자 설정
-      mimeMessageHelper.setTo(email);
-      mimeMessageHelper.setFrom(emailConfig.getMailServerUsername());
+      messageHelper.setTo(email);
+      messageHelper.setFrom(emailConfig.getMailServerUsername());
 
       // 메일의 제목 설정
-
-      mimeMessageHelper.setSubject("html 적용 테스트 메일 제목");
+      String subject = "[논술메이트] " + examFullName + " " + editingType + "이 완료되었습니다.";
+      messageHelper.setSubject(subject);
 
       // html 문법 적용한 메일의 내용
       String content =
@@ -52,7 +52,7 @@ public class EmailService {
                     </html>
                     """;
 
-      mimeMessageHelper.setText(content, true);
+      messageHelper.setText(content, true);
 
       mailSender.send(mimeMessage);
 

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/email/service/EmailService.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/email/service/EmailService.java
@@ -1,0 +1,63 @@
+package com.nonsoolmate.email.service;
+
+import jakarta.mail.internet.MimeMessage;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import com.nonsoolmate.email.config.EmailConfig;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+  private final JavaMailSender mailSender;
+  private final EmailConfig emailConfig;
+
+  public void sendMessage(String email) {
+    MimeMessage mimeMessage = mailSender.createMimeMessage();
+
+    try {
+      MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+
+      // 메일을 받을 수신자 설정
+      mimeMessageHelper.setTo(email);
+      mimeMessageHelper.setFrom(emailConfig.getMailServerUsername());
+
+      // 메일의 제목 설정
+
+      mimeMessageHelper.setSubject("html 적용 테스트 메일 제목");
+
+      // html 문법 적용한 메일의 내용
+      String content =
+          """
+                    <!DOCTYPE html>
+                    <html xmlns:th="http://www.thymeleaf.org">
+
+                    <body>
+                    <div style="margin:100px;">
+                        <h1> 테스트 메일 </h1>
+                        <br>
+
+
+                        <div align="center" style="border:1px solid black;">
+                            <h3> 테스트 메일 내용 </h3>
+                        </div>
+                        <br/>
+                    </div>
+
+                    </body>
+                    </html>
+                    """;
+
+      mimeMessageHelper.setText(content, true);
+
+      mailSender.send(mimeMessage);
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/nonsoolmate-external/src/main/java/com/nonsoolmate/email/service/EmailService.java
+++ b/nonsoolmate-external/src/main/java/com/nonsoolmate/email/service/EmailService.java
@@ -7,21 +7,23 @@ import jakarta.mail.internet.MimeMessage;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring6.SpringTemplateEngine;
 
-import com.nonsoolmate.email.config.EmailConfig;
 import com.nonsoolmate.exception.common.BusinessException;
 
 @Service
 @RequiredArgsConstructor
 public class EmailService {
   private final JavaMailSender mailSender;
-  private final EmailConfig emailConfig;
   private final SpringTemplateEngine templateEngine;
+
+  @Value("${spring.mail.username}")
+  private String fromEmail;
 
   private static final String SUBJECT_STRING_TEMPLATE = "☑️ %s %s이 완료되었습니다.";
 
@@ -33,7 +35,7 @@ public class EmailService {
       MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
 
       messageHelper.setTo(email);
-      messageHelper.setFrom(emailConfig.getMailServerUsername());
+      messageHelper.setFrom(fromEmail);
 
       String subject = SUBJECT_STRING_TEMPLATE.formatted(examFullName, editingType);
       messageHelper.setSubject(subject);

--- a/nonsoolmate-external/src/main/resources/templates/examRecordStatusTemplate.html
+++ b/nonsoolmate-external/src/main/resources/templates/examRecordStatusTemplate.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+</head>
+<body>
+<div class="email-container" style="max-width: 600px; margin: 0 auto; background-color: #fff;">
+    <div class="header" style="text-align: center; width: 600px; margin:0; padding: 0;">
+        <img style="height: auto; width: 100%;" src="https://res.cloudinary.com/dm8aymuzr/image/upload/v1728838004/crmjkzoouhyexsqgapzu.png" alt="nonsoolmate">
+    </div>
+    <div class="content" style="display: flex; align-items: flex-start; flex-direction: column; padding: 0 16px;">
+        <div class="content-text" style="margin-top: 48px; width: 100%; padding: 0;">
+            <h1 style="color: #000000; font-size: 15px;">☑️ <span th:text="${editingType}"></span>이 완료되었습니다</h1>
+            <hr style="border: 1px solid #E2E4E8; width: 100%;">
+            <p style="color: #000000; font-size: 16px; line-height: 1.5;">
+                <span style="margin:0; padding: 0" th:text="${examFullName}"></span>
+                시험 답안지의 <span style="margin:0; padding: 0" th:text="${editingType}"></span>이 완료되었습니다.<br><br>
+                참석 내용을 확인하고 다시쓰기를 통해 답안에 꼭 반영해 보세요.<br>
+                다음으로 미루지 말고, 지금 바로 확인하러 가볼까요? 👀
+            </p>
+            <button onclick="window.location.href='https://www.nonsoolmate.com/home/test'" style="display: inline-block; margin-top: 24px; margin-bottom: 48px; padding: 12px 24px; background: #6478FF; border-radius: 8px; text-align: left; color: #ffffff; border: 0; outline: 0;">논술메이트 바로가기</button>
+        </div>
+    </div>
+    <div style="background-color: #F3F4F6; color : #9196A7; padding: 16px; margin: 0; font-weight: 500; font-size: 12px; line-height: 150%;">
+       <p style="margin: 0; padding: 0;">논술메이트<br>nonsoolmate@gmail.com</p>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#108 -> dev
- closed #108

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 첨삭 결과를 기록하는 ADMIN용  API를 구현했습니다
- 이벤트 리스터를 통해 API 호출 시 첨삭을 요청한 학생에게 이메일이 발송되도록 로직을 구현했습니다
  - 트랜잭션이 커밋되었을 때에만 이메일을 발송합니다 

## 📝 테스트 결과
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
- 구현 템플릿은 다음과 같습니다
![image](https://github.com/user-attachments/assets/7217fc9c-82d8-4232-8666-e3f86644086b)

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- 디자이너의 답변에 따라 템플릿은 조금 수정될 수 있을 것 같습니다! 네이버와 gmail을 확인해봤을 때 기본 이미지가 다 다르게 보여지고있어 문의한 상태입니다!