### PR TITLE
[FEAT] 결제가 완료된 order에 대해서 isPayment 필드값 업데이트 로직 반영

### DIFF
--- a/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/PaymentService.java
+++ b/nonsoolmate-api/src/main/java/com/nonsoolmate/payment/service/PaymentService.java
@@ -71,6 +71,8 @@ public class PaymentService {
       couponMember.updateIsUsed(true);
     }
 
+    order.markAsPaid();
+
     Membership membership = membershipService.createMembership(memberId, product);
     Member member = membership.getMember();
     member.updateTicketCount(

--- a/nonsoolmate-batch/src/main/java/com/nonsoolmate/service/BillingPaymentService.java
+++ b/nonsoolmate-batch/src/main/java/com/nonsoolmate/service/BillingPaymentService.java
@@ -48,6 +48,8 @@ public class BillingPaymentService {
 
     tossPaymentService.requestBilling(billingKey, memberId, order);
 
+    order.markAsPaid();
+
     MembershipType membershipType =
         MembershipType.getMembershipType(order.getProduct().getProductName());
     membership.updateMembershipType(membershipType);

--- a/nonsoolmate-batch/src/main/java/com/nonsoolmate/service/BillingPaymentService.java
+++ b/nonsoolmate-batch/src/main/java/com/nonsoolmate/service/BillingPaymentService.java
@@ -48,7 +48,7 @@ public class BillingPaymentService {
 
     tossPaymentService.requestBilling(billingKey, memberId, order);
 
-    order.markAsPaid();
+    order.updateIsPayment(true);
 
     MembershipType membershipType =
         MembershipType.getMembershipType(order.getProduct().getProductName());

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/entity/OrderDetail.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/entity/OrderDetail.java
@@ -62,6 +62,7 @@ public class OrderDetail extends BaseTimeEntity {
     this.product = product;
     this.couponMember = couponMember;
     this.amount = amount;
+    this.isPayment = false;
   }
 
   public void updateAmount(long amount) {

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/entity/OrderDetail.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/entity/OrderDetail.java
@@ -71,4 +71,8 @@ public class OrderDetail extends BaseTimeEntity {
   public void updateCouponMember(CouponMember couponMember) {
     this.couponMember = couponMember;
   }
+
+  public void markAsPaid() {
+    this.isPayment = true;
+  }
 }

--- a/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/entity/OrderDetail.java
+++ b/nonsoolmate-db-core/src/main/java/com/nonsoolmate/order/entity/OrderDetail.java
@@ -73,7 +73,7 @@ public class OrderDetail extends BaseTimeEntity {
     this.couponMember = couponMember;
   }
 
-  public void markAsPaid() {
-    this.isPayment = true;
+  public void updateIsPayment(boolean isPayment) {
+    this.isPayment = isPayment;
   }
 }


### PR DESCRIPTION
## 📝 PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 📝 반영 브랜치
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시합니다 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 해줍니다 -->
- feat/#210 -> dev
- closed #210 

## 📝 변경 사항
<!-- 로그인 시, 구글 소셜 로그인 기능을 추가했습니다. 와 같이 작성합니다 -->
- 결제 API에서 처음에 생성되어 결제되는 Order의 isPayment 상태를 true로 업데이트하는 로직을 추가했습니다
- 스케줄러에서도 결제된 order에 대해서는 isPayment의 상태를 true로 변경하도록 반영했습니다
- OrderDetail 엔티티에 isPayment를 true로 변경하는 메서드를 만들었습니다
- Default 컬럼 값이 dev db에서 적용되지 않는 것 같아 alter문으로 dev,prod 모두 default 값을 지정해두었습니다

## 📝 To Reviewer
<!-- review 받고 싶은 point를 작성합니다 -->
- OrderDetail에 추가한 markAsPaid라는 메서드명이 괜찮을지, 해당 메서드가 쿠폰처럼 사용여부를 등록했다가 다시 false로 돌리는 경우가 발생할 수 있어 파라미터로 boolean 값을 받는게 좋을지에 대해 이야기해보고 싶습니다!!
